### PR TITLE
Added basic padding support to log level and logger name patterns

### DIFF
--- a/Example playgrounds/SoftwareConfiguration-OSX.playground/Contents.swift
+++ b/Example playgrounds/SoftwareConfiguration-OSX.playground/Contents.swift
@@ -6,7 +6,7 @@
 import Log4swift
 
 // Create formatters
-// PatternFormater init can throw an error if the pattern is not valid. Those errors are not handled in that exemple (but it should be in your code ;-) )
+// PatternFormater init can throw an error if the pattern is not valid. Those errors are not handled in that example (but it should be in your code ;-) )
 let rootFormatter = try! PatternFormatter(identifier:"rootFormatter", pattern: "[Root formatter][%l] - %m");
 let consoleFormatter = try! PatternFormatter(identifier:"consoleFormatter", pattern: "[%n][%l] - %m");
 let errorFileFormatter = try! PatternFormatter(identifier:"errorFormatter", pattern: "[%d][%n] - %m");

--- a/Log4swift/Formatters/PatternFormatter.swift
+++ b/Log4swift/Formatters/PatternFormatter.swift
@@ -25,8 +25,8 @@ The PatternFormatter will format the message according to a given pattern.
 The pattern is a regular string, with markers prefixed by '%', that might be passed options encapsulated in '{}'.
 Use '%%' to print a '%' character in the formatted message.
 Available markers are :
-* l : The name of the log level
-* n : The name of the logger
+* l{format} : The name of the log level. Format is TBD.
+* n{format} : The name of the logger. Format is TBD.
 * d{format} : The date of the log. The format is the one of the strftime function.
 * L : the number of the line where the log was issued
 * F : the name of the file where the log was issued
@@ -233,42 +233,6 @@ Available markers are :
 }
 
 
-/// Used internally by the `PatternFormatter` to pad strings left or right to a certain length.
-///
-/// - parameter value: The string value to pad
-/// - parameter width: The width of the final string.  Positive values left-justify the value, negative values right-justify it.  Default value is `0` and causes no padding to occur.
-///
-/// - returns: The padded string
-func _padString(value: String, _ width: Int = 0) -> String
-{
-  var str = value as NSString
-
-  if width == 0
-  {
-	return value
-  }
-
-  if str.length > abs(width)
-  {
-	str = str.substringWithRange(NSRange(location: 0, length: abs(width)))
-  }
-
-  if str.length < abs(width)
-  {
-	if width < 0
-	{
-		str = " ".stringByPaddingToLength(abs(width) - str.length, withString: " ", startingAtIndex: 0) + (str as String)
-	}
-	else
-	{
-	  str = str.stringByPaddingToLength(width, withString: " ", startingAtIndex: 0)
-	}
-  }
-
-  return str as String
-}
-
-
 /// Processes standard padding parameters; currently only accepts a single integer value and uses
 /// it to pad the width of the string value.
 /// - parameter value: The string value
@@ -279,15 +243,13 @@ func _padString(value: String, _ width: Int = 0) -> String
 /// - seealso: `_padString()`
 func processPaddingParameters(value: CustomStringConvertible, parameters: String?) -> String
 {
-  if let parameters = parameters
-  {
-	let scanner = NSScanner(string: parameters)
-	var width: Int = 0
+  if let parameters = parameters {
+    let scanner = NSScanner(string: parameters)
+    var width: Int = 0
 
-	if scanner.scanInteger(&width)
-	{
-	  return _padString(value.description, width)
-	}
+    if scanner.scanInteger(&width) {
+      return value.description.padtoWidth(width)
+    }
   }
 
   return value.description

--- a/Log4swift/Logger.swift
+++ b/Log4swift/Logger.swift
@@ -29,7 +29,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
     case AppenderIds = "AppenderIds"
   }
   
-  /// The UTI string that identifies the logger. Exemple : product.module.feature
+  /// The UTI string that identifies the logger. Example : product.module.feature
   public let identifier: String;
 
   internal var parent: Logger?;
@@ -38,7 +38,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   private var appendersStorage: [Appender];
 
   /// The threshold under which log messages will be ignored.
-  /// For exemple, if the threshold is Warning:
+  /// For example, if the threshold is Warning:
   /// * logs issued with a Debug or Info will be ignored
   /// * logs issued wiht a Warning, Error or Fatal level will be processed
   public var thresholdLevel: LogLevel {

--- a/Log4swift/Utilities/String+utilities.swift
+++ b/Log4swift/Utilities/String+utilities.swift
@@ -35,7 +35,39 @@ extension String {
   public func format(args: CVaListPointer) -> String {
     return NSString(format: self, arguments: args) as String
   }
+
+
+  /// Pads string left or right to a certain width.
+  ///
+  /// - parameter width: The width of the final string.  Positive values left-justify the value,
+  ///                    negative values right-justify it.  Default value is `0` and causes no
+  ///                    padding to occur.  If the string is longer than the specified width,
+  ///                    it will be truncated.
+  ///
+  /// - returns: The padded string
+  func padtoWidth(width: Int = 0) -> String {
+    var str = self as NSString
+    
+    if width == 0 {
+      return self
+    }
+    
+    if str.length > abs(width) {
+      str = str.substringWithRange(NSRange(location: 0, length: abs(width)))
+    }
+
+    if str.length < abs(width) {
+      if width < 0 {
+        str = " ".stringByPaddingToLength(abs(width) - str.length, withString: " ", startingAtIndex: 0) + (str as String)
+      } else {
+        str = str.stringByPaddingToLength(width, withString: " ", startingAtIndex: 0)
+      }
+    }
+    
+    return str as String
+  }
 }
+
 
 extension String : CustomStringConvertible {
   /// Returns the string itself (needed to conform to the CustomStringConvertible protocol)

--- a/Log4swiftTests/Formatters/PatternFormatterTests.swift
+++ b/Log4swiftTests/Formatters/PatternFormatterTests.swift
@@ -54,7 +54,49 @@ class PatternFormatterTests: XCTestCase {
     // validate
     XCTAssertEqual(formattedMessage, LogLevel.Error.description);
   }
+
+  func testFormatterAppliesLogLevelMarkerWithPadding() {
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{10}][%n] %m");
+	let info: LogInfoDictionary = [
+		LogInfoKeys.LoggerName: "nameOfTheLogger",
+		LogInfoKeys.LogLevel: LogLevel.Warning
+	];
+	
+	// Execute
+	let formattedMessage = formatter.format("Log message", info: info);
+	
+	// Validate
+	XCTAssertEqual(formattedMessage, "[\(LogLevel.Warning)   ][nameOfTheLogger] Log message");
+  }
   
+  func testFormatterAppliesLogLevelMarkerWithNegativePadding() {
+	  let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{-10}][%n] %m");
+	  let info: LogInfoDictionary = [
+		  LogInfoKeys.LoggerName: "nameOfTheLogger",
+		  LogInfoKeys.LogLevel: LogLevel.Warning
+	  ];
+	  
+	  // Execute
+	  let formattedMessage = formatter.format("Log message", info: info);
+	  
+	  // Validate
+	  XCTAssertEqual(formattedMessage, "[   \(LogLevel.Warning)][nameOfTheLogger] Log message");
+  }
+
+  func testFormatterAppliesLogLevelMarkerWithZeroPadding() {
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{0}][%n] %m");
+	let info: LogInfoDictionary = [
+		LogInfoKeys.LoggerName: "nameOfTheLogger",
+		LogInfoKeys.LogLevel: LogLevel.Warning
+	];
+	
+	// Execute
+	let formattedMessage = formatter.format("Log message", info: info);
+	
+	// Validate
+	XCTAssertEqual(formattedMessage, "[\(LogLevel.Warning)][nameOfTheLogger] Log message");
+  }
+	
   func testFormatterAppliesLoggerNameMarker() {
     let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%n");
     let info: LogInfoDictionary = [LogInfoKeys.LoggerName: "loggername"];
@@ -66,6 +108,48 @@ class PatternFormatterTests: XCTestCase {
     XCTAssertEqual(formattedMessage, "loggername");
   }
   
+  func testFormatterAppliesLoggerNameWithPadding() {
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{10}] %m");
+	let info: LogInfoDictionary = [
+		LogInfoKeys.LoggerName: "name",
+		LogInfoKeys.LogLevel: LogLevel.Warning
+	];
+	
+	// Execute
+	let formattedMessage = formatter.format("Log message", info: info);
+	
+	// Validate
+	XCTAssertEqual(formattedMessage, "[\(LogLevel.Warning)][name      ] Log message");
+  }
+  
+  func testFormatterAppliesLoggerNameWithNegativePadding() {
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{-10}] %m");
+	let info: LogInfoDictionary = [
+		LogInfoKeys.LoggerName: "name",
+		LogInfoKeys.LogLevel: LogLevel.Warning
+	];
+	
+	// Execute
+	let formattedMessage = formatter.format("Log message", info: info);
+	
+	// Validate
+	XCTAssertEqual(formattedMessage, "[\(LogLevel.Warning)][      name] Log message");
+  }
+  
+  func testFormatterAppliesLoggerNameWithZeroPadding() {
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{0}] %m");
+	let info: LogInfoDictionary = [
+		LogInfoKeys.LoggerName: "name",
+		LogInfoKeys.LogLevel: LogLevel.Warning
+	];
+	
+	// Execute
+	let formattedMessage = formatter.format("Log message", info: info);
+	
+	// Validate
+	XCTAssertEqual(formattedMessage, "[\(LogLevel.Warning)][name] Log message");
+  }
+
   func testFormatterAppliesDateMarker() {
     let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%d");
     let info = LogInfoDictionary();


### PR DESCRIPTION
Added basic padding support to log level and logger name patterns along with corresponding tests.  Can now use a single integer option for %l and %n to left or right justify and pad values to a certain length.  Also fixed exemple/example typos.
