### PR TITLE
Added initial support for named marker parameters

### DIFF
--- a/Log4swift/Formatters/PatternFormatter.swift
+++ b/Log4swift/Formatters/PatternFormatter.swift
@@ -141,12 +141,13 @@ Available markers are :
     private struct ParserStatus {
       var machineState = ParserState.Text;
       var charactersAccumulator = [Character]();
-      var parameterValues: [String:AnyObject] {
-        get {
-          return ("{" + String(charactersAccumulator) + "}").toDictionary()
+      
+      func getParameterValues() throws -> [String:AnyObject] {
+        do {
+          return try ("{" + String(charactersAccumulator) + "}").toDictionary()
         }
       }
-    };
+    }
     
     private var parserStatus = ParserStatus();
     private var parsedClosuresSequence = [FormattingClosure]();
@@ -209,7 +210,13 @@ Available markers are :
         case .End:
           throw Error.NotClosedMarkerParameter;
         default:
-          processMarker(markerName, parameters: parserStatus.parameterValues)
+          do {
+            try processMarker(markerName, parameters: parserStatus.getParameterValues())
+          }
+          catch {
+            throw Error.InvalidFormatSyntax
+          }
+
           parserStatus.charactersAccumulator.removeAll();
         }
       default:

--- a/Log4swift/Utilities/String+utilities.swift
+++ b/Log4swift/Utilities/String+utilities.swift
@@ -76,21 +76,17 @@ extension String {
   /// Returns a dictionary if String contains proper JSON format for a single, non-nested object; a simple dictionary.
   /// Keys and values should be surrounded with single or double quotes.
   /// Ex: {"name":"value", 'name':'value'}
-  public func toDictionary() -> [String:AnyObject] {
-    var dict = [:]
-
+  public func toDictionary() throws -> [String:AnyObject] {
+    var dict: [String:AnyObject] = Dictionary()
     let s = (self as NSString).stringByReplacingOccurrencesOfString("'", withString: "\"")
 
     if let data = s.dataUsingEncoding(NSUTF8StringEncoding) {
       do {
         dict = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments) as! [String:AnyObject]
       }
-      catch {
-        // TODO: Report invalid format somehow?
-      }
     }
-    
-    return dict as! [String:AnyObject]
+
+    return dict
   }
 }
 

--- a/Log4swift/Utilities/String+utilities.swift
+++ b/Log4swift/Utilities/String+utilities.swift
@@ -71,7 +71,29 @@ extension String {
     
     return str as String
   }
+
+
+  /// Returns a dictionary if String contains proper JSON format for a single, non-nested object; a simple dictionary.
+  /// Keys and values should be surrounded with single or double quotes.
+  /// Ex: {"name":"value", 'name':'value'}
+  public func toDictionary() -> [String:AnyObject] {
+    var dict = [:]
+
+    let s = (self as NSString).stringByReplacingOccurrencesOfString("'", withString: "\"")
+
+    if let data = s.dataUsingEncoding(NSUTF8StringEncoding) {
+      do {
+        dict = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments) as! [String:AnyObject]
+      }
+      catch {
+        // TODO: Report invalid format somehow?
+      }
+    }
+    
+    return dict as! [String:AnyObject]
+  }
 }
+
 
 
 extension String : CustomStringConvertible {

--- a/Log4swiftTests/Formatters/PatternFormatterTests.swift
+++ b/Log4swiftTests/Formatters/PatternFormatterTests.swift
@@ -56,7 +56,7 @@ class PatternFormatterTests: XCTestCase {
   }
 
   func testFormatterAppliesLogLevelMarkerWithPadding() {
-	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{10}][%n] %m");
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{\"padding\":\"10\"}][%n] %m");
 	let info: LogInfoDictionary = [
 		LogInfoKeys.LoggerName: "nameOfTheLogger",
 		LogInfoKeys.LogLevel: LogLevel.Warning
@@ -70,7 +70,7 @@ class PatternFormatterTests: XCTestCase {
   }
   
   func testFormatterAppliesLogLevelMarkerWithNegativePadding() {
-	  let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{-10}][%n] %m");
+	  let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{\"padding\":\"-10\"}][%n] %m");
 	  let info: LogInfoDictionary = [
 		  LogInfoKeys.LoggerName: "nameOfTheLogger",
 		  LogInfoKeys.LogLevel: LogLevel.Warning
@@ -84,7 +84,7 @@ class PatternFormatterTests: XCTestCase {
   }
 
   func testFormatterAppliesLogLevelMarkerWithZeroPadding() {
-	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{0}][%n] %m");
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l{\"padding\":\"0\"}][%n] %m");
 	let info: LogInfoDictionary = [
 		LogInfoKeys.LoggerName: "nameOfTheLogger",
 		LogInfoKeys.LogLevel: LogLevel.Warning
@@ -109,7 +109,7 @@ class PatternFormatterTests: XCTestCase {
   }
   
   func testFormatterAppliesLoggerNameWithPadding() {
-	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{10}] %m");
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{\"padding\":\"10\"}] %m");
 	let info: LogInfoDictionary = [
 		LogInfoKeys.LoggerName: "name",
 		LogInfoKeys.LogLevel: LogLevel.Warning
@@ -123,7 +123,7 @@ class PatternFormatterTests: XCTestCase {
   }
   
   func testFormatterAppliesLoggerNameWithNegativePadding() {
-	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{-10}] %m");
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{\"padding\":\"-10\"}] %m");
 	let info: LogInfoDictionary = [
 		LogInfoKeys.LoggerName: "name",
 		LogInfoKeys.LogLevel: LogLevel.Warning
@@ -137,7 +137,7 @@ class PatternFormatterTests: XCTestCase {
   }
   
   func testFormatterAppliesLoggerNameWithZeroPadding() {
-	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{0}] %m");
+	let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%l][%n{\"padding\":\"0\"}] %m");
 	let info: LogInfoDictionary = [
 		LogInfoKeys.LoggerName: "name",
 		LogInfoKeys.LogLevel: LogLevel.Warning
@@ -165,7 +165,7 @@ class PatternFormatterTests: XCTestCase {
   }
   
   func testFormatterAppliesDateMarkerWithFormat() {
-    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%d{%D %R}");
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%d{\"format\":\"%D %R\"}");
     let info = LogInfoDictionary();
     
     // Execute
@@ -177,6 +177,45 @@ class PatternFormatterTests: XCTestCase {
     let matches = validationRegexp.matchesInString(formattedMessage, options: NSMatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)));
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid");
   }  
+
+  func testFormatterAppliesDateMarkerWithFormatAndCommonParametersPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%d{'padding':'19', 'format':'%D %R'}");
+    let info = LogInfoDictionary();
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate; Datetime is 14 chars...regex has 5 trailing spaces = 19 char width
+    let validationRegexp = try! NSRegularExpression(pattern: "^\\d{2}/\\d{2}/\\d{2} \\d{2}:\\d{2}     $", options: NSRegularExpressionOptions());
+    let matches = validationRegexp.matchesInString(formattedMessage, options: NSMatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)));
+    XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid");
+  }
+
+  func testFormatterAppliesDateMarkerWithFormatAndCommonParametersNegativePadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%d{'padding':'-19', 'format':'%D %R'}");
+    let info = LogInfoDictionary();
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate; Datetime is 14 chars...regex has 5 leading spaces = 19 char width
+    let validationRegexp = try! NSRegularExpression(pattern: "^     \\d{2}/\\d{2}/\\d{2} \\d{2}:\\d{2}$", options: NSRegularExpressionOptions());
+    let matches = validationRegexp.matchesInString(formattedMessage, options: NSMatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)));
+    XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid");
+  }
+  
+  func testFormatterAppliesDateMarkerWithFormatAndCommonParametersZeroPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%d{'padding':'0', 'format':'%D %R'}");
+    let info = LogInfoDictionary();
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    let validationRegexp = try! NSRegularExpression(pattern: "^\\d{2}/\\d{2}/\\d{2} \\d{2}:\\d{2}$", options: NSRegularExpressionOptions());
+    let matches = validationRegexp.matchesInString(formattedMessage, options: NSMatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytesUsingEncoding(NSUTF8StringEncoding)));
+    XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid");
+  }
 
   func testMarkerParametersAreInterpreted() {
     let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %l{param}");
@@ -200,8 +239,74 @@ class PatternFormatterTests: XCTestCase {
     XCTAssertEqual(formattedMessage, "test testFileName");
   }
   
+  func testFormatterAppliesFileNameMarkerWithCommonParametersPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %F{'padding':'10'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileName: "12345"];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 12345     ");
+  }
+  
+  func testFormatterAppliesFileNameMarkerWithCommonParametersNegativePadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %F{'padding':'-10'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileName: "12345"];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test      12345");
+  }
+  
+  func testFormatterAppliesFileNameMarkerWithCommonParametersZeroPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %F{'padding':'0'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileName: "12345"];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 12345");
+  }
+  
   func testFormatterAppliesFileLineMarker() {
     let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %L");
+    let info: LogInfoDictionary = [LogInfoKeys.FileLine: 42];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 42");
+  }
+  
+  func testFormatterAppliesFileLineMarkerWithCommonParametersPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %L{'padding':'5'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileLine: 42];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 42   ");
+  }
+  
+  func testFormatterAppliesFileLineMarkerWithCommonParametersNegativePadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %L{'padding':'-5'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileLine: 42];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test    42");
+  }
+  
+  func testFormatterAppliesFileLineMarkerWithCommonParametersZeroPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %L{'padding':'0'}");
     let info: LogInfoDictionary = [LogInfoKeys.FileLine: 42];
     
     // Execute

--- a/Log4swiftTests/Formatters/PatternFormatterTests.swift
+++ b/Log4swiftTests/Formatters/PatternFormatterTests.swift
@@ -218,7 +218,7 @@ class PatternFormatterTests: XCTestCase {
   }
 
   func testMarkerParametersAreInterpreted() {
-    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %l{param}");
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %l{'padding':'0'}");
     let info: LogInfoDictionary = [LogInfoKeys.LogLevel: LogLevel.Debug];
     
     // Execute

--- a/Log4swiftTests/Utilities/String+utilitiesTest.swift
+++ b/Log4swiftTests/Utilities/String+utilitiesTest.swift
@@ -84,7 +84,7 @@ class String_utilitiesTest: XCTestCase {
     var dict: [String:AnyObject]
     
     // Execute
-    dict = "{\"padding\":\"-57\", \"case\": \"upper\"}".toDictionary()
+    dict = try! "{\"padding\":\"-57\", \"case\": \"upper\"}".toDictionary()
     
     // Validate
     XCTAssertEqual(dict.keys.count, 2);
@@ -94,7 +94,7 @@ class String_utilitiesTest: XCTestCase {
     
     
     // Execute
-    dict = "{'padding':'-57', 'case': 'upper'}".toDictionary()
+    dict = try! "{'padding':'-57', 'case': 'upper'}".toDictionary()
     
     // Validate
     XCTAssertEqual(dict.keys.count, 2);
@@ -103,7 +103,8 @@ class String_utilitiesTest: XCTestCase {
     XCTAssertEqual(dict["missing"] as! String?, nil);
 
   
-    dict = "{\"padding\":'-57', 'case': \"upper\"}".toDictionary()
+    // Execute
+    dict = try! "{\"padding\":'-57', 'case': \"upper\"}".toDictionary()
     
     // Validate
     XCTAssertEqual(dict.keys.count, 2);
@@ -113,25 +114,11 @@ class String_utilitiesTest: XCTestCase {
   }
 
   func testToDictionaryWithInvalidPatterns() {
-    var dict: [String:AnyObject]
+    var dict: [String:AnyObject]? = nil
     
-    // Execute
-    dict = "{\"padding\":-57, case: \"upper\"}".toDictionary()
-    
-    // Validate
-    XCTAssertEqual(dict.keys.count, 0);
-    XCTAssertEqual(dict["padding"] as! String?, nil);
-    XCTAssertEqual(dict["case"] as! String?, nil);
-    XCTAssertEqual(dict["missing"] as! String?, nil);
-
-  
-    // Execute
-    dict = "\"padding\":\"-57\", \"case\": \"upper\"".toDictionary()
-    
-    // Validate
-    XCTAssertEqual(dict.keys.count, 0);
-    XCTAssertEqual(dict["padding"] as! String?, nil);
-    XCTAssertEqual(dict["case"] as! String?, nil);
-    XCTAssertEqual(dict["missing"] as! String?, nil);
+    // Execute/Validate
+    XCTAssertThrows { try dict = "{\"padding\":-57, case: \"upper\"}".toDictionary() }
+    XCTAssertThrows { try dict = "\"padding\":\"-57\", \"case\": \"upper\"".toDictionary() }
+    XCTAssertNil(dict)
   }
 }

--- a/Log4swiftTests/Utilities/String+utilitiesTest.swift
+++ b/Log4swiftTests/Utilities/String+utilitiesTest.swift
@@ -79,4 +79,59 @@ class String_utilitiesTest: XCTestCase {
     // Validate
     XCTAssertEqual(truncatedString, "1234567890");
   }
+
+  func testToDictionaryWithValidPatterns() {
+    var dict: [String:AnyObject]
+    
+    // Execute
+    dict = "{\"padding\":\"-57\", \"case\": \"upper\"}".toDictionary()
+    
+    // Validate
+    XCTAssertEqual(dict.keys.count, 2);
+    XCTAssertEqual(dict["padding"] as! String?, "-57");
+    XCTAssertEqual(dict["case"] as! String?, "upper");
+    XCTAssertEqual(dict["missing"] as! String?, nil);
+    
+    
+    // Execute
+    dict = "{'padding':'-57', 'case': 'upper'}".toDictionary()
+    
+    // Validate
+    XCTAssertEqual(dict.keys.count, 2);
+    XCTAssertEqual(dict["padding"] as! String?, "-57");
+    XCTAssertEqual(dict["case"] as! String?, "upper");
+    XCTAssertEqual(dict["missing"] as! String?, nil);
+
+  
+    dict = "{\"padding\":'-57', 'case': \"upper\"}".toDictionary()
+    
+    // Validate
+    XCTAssertEqual(dict.keys.count, 2);
+    XCTAssertEqual(dict["padding"] as! String?, "-57");
+    XCTAssertEqual(dict["case"] as! String?, "upper");
+    XCTAssertEqual(dict["missing"] as! String?, nil);
+  }
+
+  func testToDictionaryWithInvalidPatterns() {
+    var dict: [String:AnyObject]
+    
+    // Execute
+    dict = "{\"padding\":-57, case: \"upper\"}".toDictionary()
+    
+    // Validate
+    XCTAssertEqual(dict.keys.count, 0);
+    XCTAssertEqual(dict["padding"] as! String?, nil);
+    XCTAssertEqual(dict["case"] as! String?, nil);
+    XCTAssertEqual(dict["missing"] as! String?, nil);
+
+  
+    // Execute
+    dict = "\"padding\":\"-57\", \"case\": \"upper\"".toDictionary()
+    
+    // Validate
+    XCTAssertEqual(dict.keys.count, 0);
+    XCTAssertEqual(dict["padding"] as! String?, nil);
+    XCTAssertEqual(dict["case"] as! String?, nil);
+    XCTAssertEqual(dict["missing"] as! String?, nil);
+  }
 }


### PR DESCRIPTION
Example: `Message: %m{'padding':'50'}`. (Syntax uses JSON format so the NSJSONSerialization could be used internally...not as user friendly as it could be; still consider this a bit of a cheat.) A new parameterValues property on ParserStatus converts parameters into a `Dictionary<String, AnyObject>` for now.  Later iterations could have marker-specific parameter types. Various parameter handling methods and closures were refactored to accept this dictionary of parameter values instead of a plain string.

A common 'padding' parameter is supported for all markers.  This common formatting is applied after any other marker-specific formatting is performed, such as with the date marker.  The date marker format now needs to specify a 'format' parameter.  Corresponding tests were added to cover most cases.

Prolly not the best way to go about this, but might be acceptable for a first iteration.  Really think the tokenization/parsing could use a bit of refactoring, but I plugged this in where I felt it would cause the least amount of change.  All tests pass.
