### PR TITLE
The following additions were made:

### DIFF
--- a/Log4swift/Formatters/PatternFormatter.swift
+++ b/Log4swift/Formatters/PatternFormatter.swift
@@ -32,6 +32,8 @@ Available markers are :
 * d{'padding': 'padding value', 'format': 'format specifier'} : The date of the log. The format specifier is the one of the strftime function.
 * L{'padding': 'padding value'} : the number of the line where the log was issued
 * F{'padding': 'padding value'} : the name of the file where the log was issued
+* f{'padding': 'padding value'} : the name of the file where the log was issued without the full path
+* M{'padding': 'padding value'} : the name of the function in which the log was issued
 * m{'padding': 'padding value'} : the message
 * % : the '%' character
 
@@ -117,6 +119,14 @@ Available markers are :
       "F": {(parameters, message, info) in 
         let filename = info[.FileName] ?? "-"
         return processCommonParameters(filename, parameters: parameters)
+      },
+      "f": {(parameters, message, info) in
+        let filename = NSString(string: (info[.FileName] as? String ?? "-")).lastPathComponent;
+        return processCommonParameters(filename, parameters: parameters)
+      },
+      "M": {(parameters, message, info) in
+        let function = info[.Function] ?? "-"
+        return processCommonParameters(function, parameters: parameters)
       },
       "m": {(parameters, message, info) in
         processCommonParameters(message as String, parameters: parameters)

--- a/Log4swift/LogInformation.swift
+++ b/Log4swift/LogInformation.swift
@@ -26,6 +26,7 @@ public enum LogInfoKeys {
   case LoggerName
   case FileName
   case FileLine
+  case Function
   case Timestamp
 }
 

--- a/Log4swift/LogLevel.swift
+++ b/Log4swift/LogLevel.swift
@@ -24,20 +24,24 @@ import Foundation
 Log level defines the importance of the log : is it just a debug log, an informational notice, or an error.
 Order of the levels is :
 
-Debug < Info < Warning < Error < Fatal
+Trace < Debug < Info < Warning < Error < Fatal < Off
 */
 @objc public enum LogLevel: Int, CustomStringConvertible {
   
-  case Debug = 0
-  case Info = 1
-  case Warning = 2
-  case Error = 3
-  case Fatal = 4
+  case Trace = 0
+  case Debug = 1
+  case Info = 2
+  case Warning = 3
+  case Error = 4
+  case Fatal = 5
+  case Off = 6
   
   /// Converts a string to a log level if possible.
   /// This initializer is not case sensitive
   public init?(_ stringValue: String) {
     switch(stringValue.lowercaseString) {
+    case LogLevel.Trace.description.lowercaseString:
+      self = .Trace;
     case LogLevel.Debug.description.lowercaseString:
       self = .Debug;
     case LogLevel.Info.description.lowercaseString:
@@ -48,6 +52,8 @@ Debug < Info < Warning < Error < Fatal
       self = .Error;
     case LogLevel.Fatal.description.lowercaseString:
       self = .Fatal;
+    case LogLevel.Off.description.lowercaseString:
+      self = .Off;
     default:
       return nil;
     }
@@ -57,6 +63,8 @@ Debug < Info < Warning < Error < Fatal
   public var description : String {
     get {
       switch(self) {
+      case .Trace:
+        return "Trace";
       case .Debug:
         return "Debug";
       case .Info:
@@ -67,6 +75,8 @@ Debug < Info < Warning < Error < Fatal
         return "Error";
       case .Fatal:
         return "Fatal";
+      case .Off:
+        return "Off";
       }
     }
   }

--- a/Log4swift/Logger+convenience.swift
+++ b/Log4swift/Logger+convenience.swift
@@ -28,7 +28,11 @@ extension Logger {
   }
   
   // MARK: Logging class methods
-  
+
+  /// Logs the provided message with a trace level using the root logger of the shared logger factory
+  public class func trace(format: String, _ args: CVarArgType...) {
+    LoggerFactory.sharedInstance.rootLogger.log(format.format(getVaList(args)), level: LogLevel.Trace);
+  }
   /// Logs the provided message with a debug level using the root logger of the shared logger factory
   public class func debug(format: String, _ args: CVarArgType...) {
     LoggerFactory.sharedInstance.rootLogger.log(format.format(getVaList(args)), level: LogLevel.Debug);
@@ -49,7 +53,12 @@ extension Logger {
   public class func fatal(format: String, _ args: CVarArgType...) {
     LoggerFactory.sharedInstance.rootLogger.log(format.format(getVaList(args)), level: LogLevel.Fatal);
   }
-  
+
+  /// Logs a the message returned by the closer with a trace level using the root logger of the shared logger factory
+  /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
+  @nonobjc public class func trace(closure: () -> (String)) {
+    LoggerFactory.sharedInstance.rootLogger.log(closure, level: .Trace);
+  }
   /// Logs a the message returned by the closer with a debug level using the root logger of the shared logger factory
   /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
   @nonobjc public class func debug(closure: () -> (String)) {

--- a/Log4swift/Logger+objectiveC.swift
+++ b/Log4swift/Logger+objectiveC.swift
@@ -25,7 +25,12 @@ This extension of the Logger class adds logging methods that can be exported to 
 There are multiple functions to accomodate the limitations of Objective-C (no default values for parameters notably).
 */
 extension Logger {
-  
+
+  /// Logs a trace message. This method is meant to be used from Objective-C.
+  /// When in swift, prefer the "trace" method.
+  @objc public func logTrace(message: String) {
+    self.log(message, level: LogLevel.Trace);
+  }
   /// Logs a debug message. This method is meant to be used from Objective-C.
   /// When in swift, prefer the "debug" method.
   @objc public func logDebug(message: String) {
@@ -51,33 +56,43 @@ extension Logger {
   @objc public func logFatal(message: String) {
     self.log(message, level: LogLevel.Fatal);
   }
-  
-  /// Logs a debug message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+
+  /// Logs a trace message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
+  /// When in swift, prefer the "trace" method.
+  @objc public func logTrace(message: String, file: String, line: Int, function: String) {
+    self.log(message, level: LogLevel.Trace, file: file, line: line, function: function);
+  }
+  /// Logs a debug message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "debug" method.
-  @objc public func logDebug(message: String, file: String, line: Int) {
-    self.log(message, level: LogLevel.Debug, file: file, line: line);
+  @objc public func logDebug(message: String, file: String, line: Int, function: String) {
+    self.log(message, level: LogLevel.Debug, file: file, line: line, function: function);
   }
-  /// Logs a info message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a info message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "info" method.
-  @objc public func logInfo(message: String, file: String, line: Int) {
-    self.log(message, level: LogLevel.Info, file: file, line: line);
+  @objc public func logInfo(message: String, file: String, line: Int, function: String) {
+    self.log(message, level: LogLevel.Info, file: file, line: line, function: function);
   }
-  /// Logs a warning message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a warning message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "warning" method.
-  @objc public func logWarning(message: String, file: String, line: Int) {
-    self.log(message, level: LogLevel.Warning, file: file, line: line);
+  @objc public func logWarning(message: String, file: String, line: Int, function: String) {
+    self.log(message, level: LogLevel.Warning, file: file, line: line, function: function);
   }
-  /// Logs a error message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a error message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "error" method.
-  @objc public func logError(message: String, file: String, line: Int) {
-    self.log(message, level: LogLevel.Error, file: file, line: line);
+  @objc public func logError(message: String, file: String, line: Int, function: String) {
+    self.log(message, level: LogLevel.Error, file: file, line: line, function: function);
   }
-  /// Logs a fatal message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a fatal message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "fatal" method.
-  @objc public func logFatal(message: String, file: String, line: Int) {
-    self.log(message, level: LogLevel.Fatal, file: file, line: line);
+  @objc public func logFatal(message: String, file: String, line: Int, function: String) {
+    self.log(message, level: LogLevel.Fatal, file: file, line: line, function: function);
   }
-  
+
+  /// Logs a trace message. This method is meant to be used from Objective-C.
+  /// When in swift, prefer the "trace" method.
+  @objc public func logTraceBloc(closure:() -> (String)) {
+    self.log(closure, level: LogLevel.Trace);
+  }
   /// Logs a debug message. This method is meant to be used from Objective-C.
   /// When in swift, prefer the "debug" method.
   @objc public func logDebugBloc(closure:() -> (String)) {
@@ -104,30 +119,35 @@ extension Logger {
     self.log(closure, level: LogLevel.Fatal);
   }
 
-  /// Logs a debug message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a trace message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
+  /// When in swift, prefer the "trace" method.
+  @objc public func logTraceBloc(closure:() -> (String), file: String, line: Int, function: String) {
+    self.log(closure, level: LogLevel.Trace, file: file, line: line, function: function);
+  }
+  /// Logs a debug message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "debug" method.
-  @objc public func logDebugBloc(closure:() -> (String), file: String, line: Int) {
-    self.log(closure, level: LogLevel.Debug, file: file, line: line);
+  @objc public func logDebugBloc(closure:() -> (String), file: String, line: Int, function: String) {
+    self.log(closure, level: LogLevel.Debug, file: file, line: line, function: function);
   }
-  /// Logs a info message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a info message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "info" method.
-  @objc public func logInfoBloc(closure:() -> (String), file: String, line: Int) {
-    self.log(closure, level: LogLevel.Info, file: file, line: line);
+  @objc public func logInfoBloc(closure:() -> (String), file: String, line: Int, function: String) {
+    self.log(closure, level: LogLevel.Info, file: file, line: line, function: function);
   }
-  /// Logs a warning message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a warning message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "warning" method.
-  @objc public func logWarningBloc(closure:() -> (String), file: String, line: Int) {
-    self.log(closure, level: LogLevel.Warning, file: file, line: line);
+  @objc public func logWarningBloc(closure:() -> (String), file: String, line: Int, function: String) {
+    self.log(closure, level: LogLevel.Warning, file: file, line: line, function: function);
   }
-  /// Logs a error message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a error message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "error" method.
-  @objc public func logErrorBloc(closure:() -> (String), file: String, line: Int) {
-    self.log(closure, level: LogLevel.Error, file: file, line: line);
+  @objc public func logErrorBloc(closure:() -> (String), file: String, line: Int, function: String) {
+    self.log(closure, level: LogLevel.Error, file: file, line: line, function: function);
   }
-  /// Logs a fatal message. This method is meant to be used in macros when using Objective-C, to provide the file and line using the __FILE__ and __LINE__ macros.
+  /// Logs a fatal message. This method is meant to be used in macros when using Objective-C, to provide the file, line and function using the __FILE__, __LINE__ and __FUNCTION__ macros.
   /// When in swift, prefer the "fatal" method.
-  @objc public func logFatalBloc(closure:() -> (String), file: String, line: Int) {
-    self.log(closure, level: LogLevel.Fatal, file: file, line: line);
+  @objc public func logFatalBloc(closure:() -> (String), file: String, line: Int, function: String) {
+    self.log(closure, level: LogLevel.Fatal, file: file, line: line, function: function);
   }
   
 }

--- a/Log4swift/Logger.swift
+++ b/Log4swift/Logger.swift
@@ -149,52 +149,61 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   }
   
   // MARK: Logging methods
-  
+
+  /// Logs the provided message with a trace level.
+  @nonobjc public func trace(format: String, file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, _ args: CVarArgType...) {
+    self.log(format.format(getVaList(args)), level: LogLevel.Trace, file: file, line: line, function: function);
+  }
   /// Logs the provided message with a debug level.
-  @nonobjc public func debug(format: String, file: String = __FILE__, line: Int = __LINE__, _ args: CVarArgType...) {
-    self.log(format.format(getVaList(args)), level: LogLevel.Debug, file: file, line: line);
+  @nonobjc public func debug(format: String, file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, _ args: CVarArgType...) {
+    self.log(format.format(getVaList(args)), level: LogLevel.Debug, file: file, line: line, function: function);
   }
   /// Logs the provided message with an info level
-  @nonobjc public func info(format: String, file: String = __FILE__, line: Int = __LINE__, _ args: CVarArgType...) {
-    self.log(format.format(getVaList(args)), level: LogLevel.Info, file: file, line: line);
+  @nonobjc public func info(format: String, file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, _ args: CVarArgType...) {
+    self.log(format.format(getVaList(args)), level: LogLevel.Info, file: file, line: line, function: function);
   }
   /// Logs the provided message with a warning level
-  @nonobjc public func warning(format: String, file: String = __FILE__, line: Int = __LINE__, _ args: CVarArgType...) {
-    self.log(format.format(getVaList(args)), level: LogLevel.Warning, file: file, line: line);
+  @nonobjc public func warning(format: String, file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, _ args: CVarArgType...) {
+    self.log(format.format(getVaList(args)), level: LogLevel.Warning, file: file, line: line, function: function);
   }
   /// Logs the provided message with an error level
-  @nonobjc public func error(format: String, file: String = __FILE__, line: Int = __LINE__, _ args: CVarArgType...) {
-    self.log(format.format(getVaList(args)), level: LogLevel.Error, file: file, line: line);
+  @nonobjc public func error(format: String, file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, _ args: CVarArgType...) {
+    self.log(format.format(getVaList(args)), level: LogLevel.Error, file: file, line: line, function: function);
   }
   /// Logs the provided message with a fatal level
-  @nonobjc public func fatal(format: String, file: String = __FILE__, line: Int = __LINE__, _ args: CVarArgType...) {
-    self.log(format.format(getVaList(args)), level: LogLevel.Fatal, file: file, line: line);
+  @nonobjc public func fatal(format: String, file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, _ args: CVarArgType...) {
+    self.log(format.format(getVaList(args)), level: LogLevel.Fatal, file: file, line: line, function: function);
   }
-  
+
   /// Logs a the message returned by the closure with a debug level
   /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
-  @nonobjc public func debug(file: String = __FILE__, line: Int = __LINE__, closure: () -> String) {
-    self.log(closure, level: LogLevel.Debug, file: file, line: line);
+  @nonobjc public func trace(file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, closure: () -> String) {
+    self.log(closure, level: LogLevel.Trace, file: file, line: line, function: function);
+  }
+  /// Logs a the message returned by the closure with a debug level
+  /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
+  @nonobjc public func debug(file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, closure: () -> String) {
+    self.log(closure, level: LogLevel.Debug, file: file, line: line, function: function);
   }
   /// Logs a the message returned by the closure with an info level
   /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
-  @nonobjc public func info(file: String = __FILE__, line: Int = __LINE__, closure: () -> String) {
-    self.log(closure, level: LogLevel.Info, file: file, line: line);
+  @nonobjc public func info(file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, closure: () -> String) {
+    self.log(closure, level: LogLevel.Info, file: file, line: line, function: function);
   }
   /// Logs a the message returned by the closure with a warning level
   /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
-  @nonobjc public func warning(file: String = __FILE__, line: Int = __LINE__, closure: () -> String) {
-    self.log(closure, level: LogLevel.Warning, file: file, line: line);
+  @nonobjc public func warning(file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, closure: () -> String) {
+    self.log(closure, level: LogLevel.Warning, file: file, line: line, function: function);
   }
   /// Logs a the message returned by the closure with an error level
   /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
-  @nonobjc public func error(file: String = __FILE__, line: Int = __LINE__, closure: () -> String) {
-    self.log(closure, level: LogLevel.Error, file: file, line: line);
+  @nonobjc public func error(file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, closure: () -> String) {
+    self.log(closure, level: LogLevel.Error, file: file, line: line, function: function);
   }
   /// Logs a the message returned by the closure with a fatal level
   /// If the logger's or appender's configuration prevents the message to be issued, the closure will not be called.
-  @nonobjc public func fatal(file: String = __FILE__, line: Int = __LINE__, closure: () -> String) {
-    self.log(closure, level: LogLevel.Fatal, file: file, line: line);
+  @nonobjc public func fatal(file: String = __FILE__, line: Int = __LINE__, function: String = __FUNCTION__, closure: () -> String) {
+    self.log(closure, level: LogLevel.Fatal, file: file, line: line, function: function);
   }
   
   /// Returns true if a message sent with the given level will be issued by at least one appender.
@@ -204,7 +213,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
     }
   }
   
-  @nonobjc internal func log(message: String, level: LogLevel, file: String? = nil, line: Int? = nil) {
+  @nonobjc internal func log(message: String, level: LogLevel, file: String? = nil, line: Int? = nil, function: String? = nil) {
     if(self.willIssueLogForLevel(level)) {
       var info: LogInfoDictionary = [
         .LoggerName: self.identifier,
@@ -216,6 +225,9 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
       }
       if let line = line {
         info[.FileLine] = line;
+      }
+      if let function = function {
+        info[.Function] = function;
       }
 
       let logClosure = {
@@ -228,7 +240,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
     }
   }
   
-  @nonobjc internal func log(closure: () -> (String), level: LogLevel, file: String? = nil, line: Int? = nil) {
+  @nonobjc internal func log(closure: () -> (String), level: LogLevel, file: String? = nil, line: Int? = nil, function: String? = nil) {
     if(self.willIssueLogForLevel(level)) {
       var info: LogInfoDictionary = [
         .LoggerName: self.identifier,
@@ -241,7 +253,10 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
       if let line = line {
         info[.FileLine] = line;
       }
-      
+      if let function = function {
+        info[.Function] = function;
+      }
+
       let logClosure = {
         let logMessage = closure();
         for currentAppender in self.appenders {

--- a/Log4swift/LoggerFactory.swift
+++ b/Log4swift/LoggerFactory.swift
@@ -112,7 +112,8 @@ extension LoggerFactory {
     xcodeAppender.setTextColor(.Red, level: .Error);
     xcodeAppender.setTextColor(.Orange, level: .Warning);
     xcodeAppender.setTextColor(.Blue, level: .Info);
-    xcodeAppender.setTextColor(.LightGrey, level: .Debug);
+    xcodeAppender.setTextColor(.DarkGrey, level: .Debug);
+    xcodeAppender.setTextColor(.LightGrey, level: .Trace);
 
     do {
       let formatter = try PatternFormatter(identifier: "xcodeFormatter", pattern: "%d{'format':'%F %T'} %m");

--- a/Log4swift/Objective-c wrappers/ASLWrapper.m
+++ b/Log4swift/Objective-c wrappers/ASLWrapper.m
@@ -106,6 +106,7 @@
 - (int)_logLevelToAslLevel:(LogLevel)logLevel {
   int aslLogLevel = ASL_LEVEL_DEBUG;
   switch(logLevel) {
+    case LogLevelTrace:
     case LogLevelDebug:
       aslLogLevel = ASL_LEVEL_DEBUG;
       break;
@@ -121,6 +122,11 @@
     case LogLevelFatal:
       aslLogLevel = ASL_LEVEL_CRIT;
       break;
+    case LogLevelOff:
+      // If the LogLevel is OFF this piece of code should have never been reached in the first place
+      // Mapping it to ASL_LEVEL_CRIT if does nevertheless.
+      aslLogLevel = ASL_LEVEL_CRIT;
+          break;
   }
   return aslLogLevel;
 }

--- a/Log4swiftTests/Formatters/PatternFormatterTests.swift
+++ b/Log4swiftTests/Formatters/PatternFormatterTests.swift
@@ -287,6 +287,50 @@ class PatternFormatterTests: XCTestCase {
     XCTAssertEqual(formattedMessage, "test 12345");
   }
   
+  func testFormatterAppliesShortFileNameMarker() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %f");
+    let info: LogInfoDictionary = [LogInfoKeys.FileName: "/test/testFileName.txt"];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test testFileName.txt");
+  }
+  
+  func testFormatterAppliesShortFileNameMarkerWithCommonParametersPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %f{'padding':'10'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileName: "/test/12345"];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 12345     ");
+  }
+  
+  func testFormatterAppliesShortFileNameMarkerWithCommonParametersNegativePadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %f{'padding':'-10'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileName: "/test/12345"];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test      12345");
+  }
+  
+  func testFormatterAppliesShortFileNameMarkerWithCommonParametersZeroPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %f{'padding':'0'}");
+    let info: LogInfoDictionary = [LogInfoKeys.FileName: "/test/12345"];
+    
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+    
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 12345");
+  }
+  
   func testFormatterAppliesFileLineMarker() {
     let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %L");
     let info: LogInfoDictionary = [LogInfoKeys.FileLine: 42];
@@ -330,7 +374,51 @@ class PatternFormatterTests: XCTestCase {
     // Validate
     XCTAssertEqual(formattedMessage, "test 42");
   }
-  
+
+  func testFormatterAppliesFunctionMarker() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %M");
+    let info: LogInfoDictionary = [LogInfoKeys.Function: "testFunction"];
+
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+
+    // Validate
+    XCTAssertEqual(formattedMessage, "test testFunction");
+  }
+
+  func testFormatterAppliesFunctionMarkerWithCommonParametersPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %M{'padding':'10'}");
+    let info: LogInfoDictionary = [LogInfoKeys.Function: "12345"];
+
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 12345     ");
+  }
+
+  func testFormatterAppliesFunctionMarkerWithCommonParametersNegativePadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %M{'padding':'-10'}");
+    let info: LogInfoDictionary = [LogInfoKeys.Function: "12345"];
+
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+
+    // Validate
+    XCTAssertEqual(formattedMessage, "test      12345");
+  }
+
+  func testFormatterAppliesFunctionMarkerWithCommonParametersZeroPadding() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %M{'padding':'0'}");
+    let info: LogInfoDictionary = [LogInfoKeys.Function: "12345"];
+
+    // Execute
+    let formattedMessage = formatter.format("", info: info);
+
+    // Validate
+    XCTAssertEqual(formattedMessage, "test 12345");
+  }
+
   func testFormatterAppliesPercentageMarker() {
     let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "test %%");
     let info = LogInfoDictionary();
@@ -368,14 +456,14 @@ class PatternFormatterTests: XCTestCase {
   }
   
   func testFormatterReturnsDashIfDataUnavailableForMarkers() {
-    let formatter = try! PatternFormatter(identifier: "testFormatter", pattern: "[%l][%n][%F][%L] %m");
+    let formatter = try! PatternFormatter(identifier: "testFormatter", pattern: "[%l][%n][%F][%f][%L][%M] %m");
     let info = LogInfoDictionary();
     
     // Execute
     let formattedMessage = formatter.format("Log message", info: info);
     
     // Validate
-    XCTAssertEqual(formattedMessage, "[-][-][-][-] Log message");
+    XCTAssertEqual(formattedMessage, "[-][-][-][-][-][-] Log message");
   }
 
   func testUpdatingFormatterFromDictionaryWithNoPatternThrowsError() {

--- a/Log4swiftTests/FunctionalTests.swift
+++ b/Log4swiftTests/FunctionalTests.swift
@@ -61,13 +61,14 @@ class FunctionalTests: XCTestCase {
     XCTAssertEqual(appender2.logMessages[0].message, "[test.identifier][\(LogLevel.Fatal)] this log should be printed to both appenders");
   }
   
-  func testCurrentFileNameAndFileIsSentWhenLoggingString() {
-    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L] %m");
+  func testCurrentFileNameAndLineAndFunctionIsSentWhenLoggingString() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L]:[%M] %m");
     let appender = MemoryAppender();
     appender.thresholdLevel = .Debug;
     appender.formatter = formatter;
     let logger = Logger(identifier: "test.identifier", level: .Debug, appenders: [appender]);
     let file = __FILE__;
+    let function = __FUNCTION__;
     let previousLine: Int;
     
     // Execute
@@ -75,16 +76,17 @@ class FunctionalTests: XCTestCase {
     logger.debug("This is a debug message");
     
     // Validate
-    XCTAssertEqual(appender.logMessages[0].message, "[\(file)]:[\(previousLine + 1)] This is a debug message");
+    XCTAssertEqual(appender.logMessages[0].message, "[\(file)]:[\(previousLine + 1)]:[\(function)] This is a debug message");
   }
   
-  func testCurrentFileNameAndFileIsSentWhenLoggingStringWithFormat() {
-    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L] %m");
+  func testCurrentFileNameAndLineAndFunctionIsSentWhenLoggingStringWithFormat() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L]:[%M] %m");
     let appender = MemoryAppender();
     appender.thresholdLevel = .Debug;
     appender.formatter = formatter;
     let logger = Logger(identifier: "test.identifier", level: .Debug, appenders: [appender]);
     let file = __FILE__;
+    let function = __FUNCTION__;
     let previousLine: Int;
     
     // Execute
@@ -92,16 +94,17 @@ class FunctionalTests: XCTestCase {
     logger.debug("This is a %@ message", LogLevel.Debug.description);
     
     // Validate
-    XCTAssertEqual(appender.logMessages[0].message, "[\(file)]:[\(previousLine + 1)] This is a \(LogLevel.Debug.description) message");
+    XCTAssertEqual(appender.logMessages[0].message, "[\(file)]:[\(previousLine + 1)]:[\(function)] This is a \(LogLevel.Debug.description) message");
   }
   
-  func testCurrentFileNameAndFileIsSentWhenLoggingClosure() {
-    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L] %m");
+  func testCurrentFileNameAndLineAndFunctionIsSentWhenLoggingClosure() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L]:[%M] %m");
     let appender = MemoryAppender();
     appender.thresholdLevel = .Debug;
     appender.formatter = formatter;
     let logger = Logger(identifier: "test.identifier", level: .Debug, appenders: [appender]);
     let file = __FILE__;
+    let function = __FUNCTION__;
     let previousLine: Int;
     
     // Execute
@@ -109,6 +112,6 @@ class FunctionalTests: XCTestCase {
     logger.debug {"This is a debug message"};
     
     // Validate
-    XCTAssertEqual(appender.logMessages[0].message, "[\(file)]:[\(previousLine + 1)] This is a debug message");
+    XCTAssertEqual(appender.logMessages[0].message, "[\(file)]:[\(previousLine + 1)]:[\(function)] This is a debug message");
   }
 }

--- a/Log4swiftTests/LogLevelTests.swift
+++ b/Log4swiftTests/LogLevelTests.swift
@@ -38,12 +38,14 @@ class LogLevelTests: XCTestCase {
   }
   
   func testLogLevelFromStringCanConvertAllLogLevels() {
+    let parsedTrace = LogLevel("trace");
     let parsedDebug = LogLevel("debug");
     let parsedInfo = LogLevel("info");
     let parsedWarning = LogLevel("warning");
     let parsedError = LogLevel("error");
     let parsedFatal = LogLevel("fatal");
-    
+
+    XCTAssertEqual(parsedTrace!, LogLevel.Trace);
     XCTAssertEqual(parsedDebug!, LogLevel.Debug);
     XCTAssertEqual(parsedInfo!, LogLevel.Info);
     XCTAssertEqual(parsedWarning!, LogLevel.Warning);

--- a/Log4swiftTests/Logger+objectiveCTests.swift
+++ b/Log4swiftTests/Logger+objectiveCTests.swift
@@ -25,9 +25,11 @@ class LoggerObjectiveCTests: XCTestCase {
   
   func testLoggerObjectiveCLogStringMethodsLogsAtExpectedLevel() {
     let appender = MemoryAppender();
-    let logger = Logger(identifier: "test.logger", level: LogLevel.Debug, appenders: [appender]);
+    appender.thresholdLevel = .Trace;
+    let logger = Logger(identifier: "test.logger", level: LogLevel.Trace, appenders: [appender]);
     
     // Execute
+    logger.logTrace("trace");
     logger.logDebug("debug");
     logger.logInfo("info");
     logger.logWarning("warning");
@@ -35,18 +37,21 @@ class LoggerObjectiveCTests: XCTestCase {
     logger.logFatal("fatal");
     
     // Validate
-    XCTAssertEqual(appender.logMessages[0].level, LogLevel.Debug);
-    XCTAssertEqual(appender.logMessages[1].level, LogLevel.Info);
-    XCTAssertEqual(appender.logMessages[2].level, LogLevel.Warning);
-    XCTAssertEqual(appender.logMessages[3].level, LogLevel.Error);
-    XCTAssertEqual(appender.logMessages[4].level, LogLevel.Fatal);
+    XCTAssertEqual(appender.logMessages[0].level, LogLevel.Trace);
+    XCTAssertEqual(appender.logMessages[1].level, LogLevel.Debug);
+    XCTAssertEqual(appender.logMessages[2].level, LogLevel.Info);
+    XCTAssertEqual(appender.logMessages[3].level, LogLevel.Warning);
+    XCTAssertEqual(appender.logMessages[4].level, LogLevel.Error);
+    XCTAssertEqual(appender.logMessages[5].level, LogLevel.Fatal);
   }
   
   func testLoggerObjectiveCLogBlocMethodsLogsAtExpectedLevel() {
     let appender = MemoryAppender();
-    let logger = Logger(identifier: "test.logger", level: LogLevel.Debug, appenders: [appender]);
+    appender.thresholdLevel = .Trace;
+    let logger = Logger(identifier: "test.logger", level: LogLevel.Trace, appenders: [appender]);
     
     // Execute
+    logger.logTraceBloc({"Trace"});
     logger.logDebugBloc({"Debug"});
     logger.logInfoBloc({"info"});
     logger.logWarningBloc({"warning"});
@@ -54,53 +59,60 @@ class LoggerObjectiveCTests: XCTestCase {
     logger.logFatalBloc({"fatal"});
     
     // Validate
-    XCTAssertEqual(appender.logMessages[0].level, LogLevel.Debug);
-    XCTAssertEqual(appender.logMessages[1].level, LogLevel.Info);
-    XCTAssertEqual(appender.logMessages[2].level, LogLevel.Warning);
-    XCTAssertEqual(appender.logMessages[3].level, LogLevel.Error);
-    XCTAssertEqual(appender.logMessages[4].level, LogLevel.Fatal);
+    XCTAssertEqual(appender.logMessages[0].level, LogLevel.Trace);
+    XCTAssertEqual(appender.logMessages[1].level, LogLevel.Debug);
+    XCTAssertEqual(appender.logMessages[2].level, LogLevel.Info);
+    XCTAssertEqual(appender.logMessages[3].level, LogLevel.Warning);
+    XCTAssertEqual(appender.logMessages[4].level, LogLevel.Error);
+    XCTAssertEqual(appender.logMessages[5].level, LogLevel.Fatal);
   }
   
   func testLoggerObjectiveCLogBlocWithFileAndLineMethodsLogsWithFileAndLine() {
     let appender = MemoryAppender();
-    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L] %m");
+    appender.thresholdLevel = .Trace;
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L]:[%M] %m");
     appender.formatter = formatter;
-    let logger = Logger(identifier: "test.logger", level: LogLevel.Debug, appenders: [appender]);
+    let logger = Logger(identifier: "test.logger", level: LogLevel.Trace, appenders: [appender]);
     
     // Execute
-    logger.logDebugBloc({"message"}, file: "filename", line: 42);
-    logger.logInfoBloc({"message"}, file: "filename", line: 42);
-    logger.logWarningBloc({"message"}, file: "filename", line: 42);
-    logger.logErrorBloc({"message"}, file: "filename", line: 42);
-    logger.logFatalBloc({"message"}, file: "filename", line: 42);
+    logger.logTraceBloc({"message"}, file: "filename", line: 42, function: "function");
+    logger.logDebugBloc({"message"}, file: "filename", line: 42, function: "function");
+    logger.logInfoBloc({"message"}, file: "filename", line: 42, function: "function");
+    logger.logWarningBloc({"message"}, file: "filename", line: 42, function: "function");
+    logger.logErrorBloc({"message"}, file: "filename", line: 42, function: "function");
+    logger.logFatalBloc({"message"}, file: "filename", line: 42, function: "function");
     
     // Validate
-    XCTAssertEqual(appender.logMessages[0].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[1].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[2].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[3].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[4].message, "[filename]:[42] message");
+    XCTAssertEqual(appender.logMessages[0].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[1].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[2].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[3].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[4].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[5].message, "[filename]:[42]:[function] message");
   }
   
   
   func testLoggerObjectiveCLogMessageWithFileAndLineMethodsLogsWithFileAndLine() {
     let appender = MemoryAppender();
-    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L] %m");
+    appender.thresholdLevel = .Trace;
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "[%F]:[%L]:[%M] %m");
     appender.formatter = formatter;
-    let logger = Logger(identifier: "test.logger", level: LogLevel.Debug, appenders: [appender]);
+    let logger = Logger(identifier: "test.logger", level: LogLevel.Trace, appenders: [appender]);
     
     // Execute
-    logger.logDebug("message", file: "filename", line: 42);
-    logger.logInfo("message", file: "filename", line: 42);
-    logger.logWarning("message", file: "filename", line: 42);
-    logger.logError("message", file: "filename", line: 42);
-    logger.logFatal("message", file: "filename", line: 42);
+    logger.logTrace("message", file: "filename", line: 42, function: "function");
+    logger.logDebug("message", file: "filename", line: 42, function: "function");
+    logger.logInfo("message", file: "filename", line: 42, function: "function");
+    logger.logWarning("message", file: "filename", line: 42, function: "function");
+    logger.logError("message", file: "filename", line: 42, function: "function");
+    logger.logFatal("message", file: "filename", line: 42, function: "function");
     
     // Validate
-    XCTAssertEqual(appender.logMessages[0].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[1].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[2].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[3].message, "[filename]:[42] message");
-    XCTAssertEqual(appender.logMessages[4].message, "[filename]:[42] message");
+    XCTAssertEqual(appender.logMessages[0].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[1].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[2].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[3].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[4].message, "[filename]:[42]:[function] message");
+    XCTAssertEqual(appender.logMessages[5].message, "[filename]:[42]:[function] message");
   }
 }

--- a/Log4swiftTests/LoggerFactoryTests.swift
+++ b/Log4swiftTests/LoggerFactoryTests.swift
@@ -178,7 +178,7 @@ class LoggerFactoryTests: XCTestCase {
     
     // Validate
     if let xcodeAppender = self.factory.rootLogger.appenders[0] as? StdOutAppender {
-      XCTAssertEqual(xcodeAppender.textColors.count, 5);
+      XCTAssertEqual(xcodeAppender.textColors.count, 6);
     }
   }
   

--- a/Log4swiftTests/LoggerTests.swift
+++ b/Log4swiftTests/LoggerTests.swift
@@ -133,11 +133,27 @@ class LoggerTests: XCTestCase {
     };
     
     // Validate
-    XCTAssertTrue(closureCalled, "Closure should  have been called")
+    XCTAssertTrue(closureCalled, "Closure should have been called")
   }
   
   //MARK: Static log methods
-  
+
+  func testStaticLogTraceMessageMethodsLogToRootLogger() {
+    let memoryAppender = MemoryAppender();
+    memoryAppender.thresholdLevel = .Trace;
+
+    LoggerFactory.sharedInstance.rootLogger.appenders.removeAll();
+    LoggerFactory.sharedInstance.rootLogger.appenders.append(memoryAppender);
+    LoggerFactory.sharedInstance.rootLogger.thresholdLevel = .Trace;
+
+    //Execute
+    Logger.trace("ping");
+
+    // Validate
+    XCTAssertEqual(memoryAppender.logMessages.count, 1);
+    XCTAssertEqual(memoryAppender.logMessages[0].level, LogLevel.Trace);
+  }
+
   func testStaticLogDebugMessageMethodsLogToRootLogger() {
     let memoryAppender = MemoryAppender();
     LoggerFactory.sharedInstance.rootLogger.appenders.removeAll();
@@ -202,7 +218,23 @@ class LoggerTests: XCTestCase {
     XCTAssertEqual(memoryAppender.logMessages.count, 1);
     XCTAssertEqual(memoryAppender.logMessages[0].level, LogLevel.Fatal);
   }
-  
+
+  func testStaticLogTraceClosureMethodsLogToRootLogger() {
+    let memoryAppender = MemoryAppender();
+    memoryAppender.thresholdLevel = .Trace;
+
+    LoggerFactory.sharedInstance.rootLogger.appenders.removeAll();
+    LoggerFactory.sharedInstance.rootLogger.appenders.append(memoryAppender);
+    LoggerFactory.sharedInstance.rootLogger.thresholdLevel = .Trace;
+
+    //Execute
+    Logger.trace{ return "ping"; };
+
+    // Validate
+    XCTAssertEqual(memoryAppender.logMessages.count, 1);
+    XCTAssertEqual(memoryAppender.logMessages[0].level, LogLevel.Trace);
+  }
+
   func testStaticLogDebugClosureMethodsLogToRootLogger() {
     let memoryAppender = MemoryAppender();
     LoggerFactory.sharedInstance.rootLogger.appenders.removeAll();
@@ -421,9 +453,12 @@ class LoggerTests: XCTestCase {
   
   func testLoggerMethodsFormatsString() {
     let appender = MemoryAppender();
-    let logger = Logger(identifier: "test.logger", level: LogLevel.Debug, appenders: [appender]);
+    appender.thresholdLevel = .Trace;
+
+    let logger = Logger(identifier: "test.logger", level: LogLevel.Trace, appenders: [appender]);
     
     // Execute
+    logger.trace("ping %@ %02x", "blabla", 12);
     logger.debug("ping %@ %02x", "blabla", 12);
     logger.info("ping %@ %02x", "blabla", 12);
     logger.warning("ping %@ %02x", "blabla", 12);
@@ -436,13 +471,18 @@ class LoggerTests: XCTestCase {
     XCTAssertEqual(appender.logMessages[2].message, "ping blabla 0c");
     XCTAssertEqual(appender.logMessages[3].message, "ping blabla 0c");
     XCTAssertEqual(appender.logMessages[4].message, "ping blabla 0c");
+    XCTAssertEqual(appender.logMessages[5].message, "ping blabla 0c");
   }
   
   func testLoggerConvenienceMethodsFormatsMessages() {
     let appender = MemoryAppender();
+    appender.thresholdLevel = .Trace;
+
     LoggerFactory.sharedInstance.rootLogger.appenders = [appender];
-    
+    LoggerFactory.sharedInstance.rootLogger.thresholdLevel = .Trace;
+
     // Execute
+    Logger.trace("ping %@ %02x", "blabla", 12);
     Logger.debug("ping %@ %02x", "blabla", 12);
     Logger.info("ping %@ %02x", "blabla", 12);
     Logger.warning("ping %@ %02x", "blabla", 12);
@@ -455,6 +495,7 @@ class LoggerTests: XCTestCase {
     XCTAssertEqual(appender.logMessages[2].message, "ping blabla 0c");
     XCTAssertEqual(appender.logMessages[3].message, "ping blabla 0c");
     XCTAssertEqual(appender.logMessages[4].message, "ping blabla 0c");
+    XCTAssertEqual(appender.logMessages[5].message, "ping blabla 0c");
   }
   
   //MARK: Parent relationship


### PR DESCRIPTION
Added LogLevel.Off so one can turn off a logger/appender without having to remove anything from the configuration.
Added LogLevel.Trace which will be used in the upcoming logging methods "entering" and "exiting" to log the program flow.
Added the ability to output the current filename without the path by using %f in the formatting pattern.
Added the ability to output the current function by using %M in the formatting pattern.
