### PR TITLE
Added explicit cast to ASLWrapper ASL FILTER MASK to build on Carthage for Swift 3.1

### DIFF
--- a/Log4swift/Objective-c wrappers/ASLWrapper.m
+++ b/Log4swift/Objective-c wrappers/ASLWrapper.m
@@ -31,7 +31,7 @@
   self = [super init];
   if (self) {
     logClient = asl_open(NULL, NULL, 0);
-    char filter = ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG);
+    char filter = (char) ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG);
     asl_set_filter(logClient, filter); // We don't want ASL to filter messages
     loggingQueue = dispatch_queue_create("Log4swift.ASLLoggingQueue", DISPATCH_QUEUE_SERIAL);
   }


### PR DESCRIPTION
When building Log4Swift with Carthage you get the following message
The following build commands failed:
CompileC build/Log4swift.build/Release/log4swift_OSX.build/Objects-normal/x86_64/ASLWrapper.o Log4swift/Objective-c\ wrappers/ASLWrapper.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler
Log4swift/Log4swift/Objective-c wrappers/ASLWrapper.m:34:19: error: implicit conversion from 'int' to 'char' changes value from 255 to -1 [-Werror,-Wconstant-conversion]