### PR TITLE
add support for watchOS

### DIFF
--- a/Log4swift.podspec
+++ b/Log4swift.podspec
@@ -21,10 +21,13 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"
+  s.watchos.deployment_target = "2.0"
 
   s.source       = { :git => "https://github.com/jduquennoy/Log4swift.git", :tag => "versions/1.0.1" }
 
   s.source_files = "Log4swift", "Log4swift/**/*.{swift,h,m}", "Third parties/**/*.{h,m}"
 
   s.public_header_files = ["Log4swift/log4swift.h", "Third Parties/NSLogger/*.h", "Log4swift/Objective-c wrappers/*.h"]
+
+  s.watchos.exclude_files = ["Third Parties/NSLogger/*", "Log4swift/Appenders/NSLoggerAppender.swift"]
 end

--- a/Log4swift.xcodeproj/project.pbxproj
+++ b/Log4swift.xcodeproj/project.pbxproj
@@ -113,6 +113,9 @@
 		5EFEFA971B69388800A28A53 /* ASLWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EFEFA951B69388800A28A53 /* ASLWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5EFEFA981B69388800A28A53 /* ASLWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EFEFA961B69388800A28A53 /* ASLWrapper.m */; };
 		780744AF1E1BA14C003FA519 /* SubclassingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780744AE1E1BA14C003FA519 /* SubclassingTests.swift */; };
+		78389E471ECC26B0008898E7 /* Class+utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78389E461ECC26B0008898E7 /* Class+utilities.swift */; };
+		78389E481ECC26B0008898E7 /* Class+utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78389E461ECC26B0008898E7 /* Class+utilities.swift */; };
+		78389E491ECC26B0008898E7 /* Class+utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78389E461ECC26B0008898E7 /* Class+utilities.swift */; };
 		D9322BF91B440E7D00C9F6D9 /* Array+utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9322BF81B440E7D00C9F6D9 /* Array+utilities.swift */; };
 		D9B229E41B443B670001EE9A /* Array+utilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9B229E31B443B670001EE9A /* Array+utilitiesTests.swift */; };
 /* End PBXBuildFile section */
@@ -193,6 +196,7 @@
 		5EFEFA951B69388800A28A53 /* ASLWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ASLWrapper.h; path = "Log4swift/Objective-c wrappers/ASLWrapper.h"; sourceTree = "<group>"; };
 		5EFEFA961B69388800A28A53 /* ASLWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ASLWrapper.m; path = "Log4swift/Objective-c wrappers/ASLWrapper.m"; sourceTree = "<group>"; };
 		780744AE1E1BA14C003FA519 /* SubclassingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubclassingTests.swift; sourceTree = "<group>"; };
+		78389E461ECC26B0008898E7 /* Class+utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Class+utilities.swift"; sourceTree = "<group>"; };
 		D9322BF81B440E7D00C9F6D9 /* Array+utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+utilities.swift"; sourceTree = "<group>"; };
 		D9B229E31B443B670001EE9A /* Array+utilitiesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+utilitiesTests.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -275,6 +279,7 @@
 				5E66F7691B42C959009395CE /* Bool+utilities.swift */,
 				D9322BF81B440E7D00C9F6D9 /* Array+utilities.swift */,
 				0241A2D71C32ACD400A624CF /* FileObserver.swift */,
+				78389E461ECC26B0008898E7 /* Class+utilities.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -673,6 +678,7 @@
 				D9322BF91B440E7D00C9F6D9 /* Array+utilities.swift in Sources */,
 				5E4D39121B690DC40006961C /* NSLogAppender.swift in Sources */,
 				02B8F6201B30A1DD0077A8A6 /* FileAppender.swift in Sources */,
+				78389E471ECC26B0008898E7 /* Class+utilities.swift in Sources */,
 				5EA3F1571B5D2DEA00B7C420 /* Logger+objectiveC.swift in Sources */,
 				024FD79C1B2DD3FE00A8609C /* String+utilities.swift in Sources */,
 				02664C2B1B2D97DE00B695DE /* LogLevel.swift in Sources */,
@@ -739,6 +745,7 @@
 				5E3F86EA1DC25EE3008F296C /* StdOutAppender.swift in Sources */,
 				5E3F86E81DC25EDF008F296C /* Errors.swift in Sources */,
 				5E3F86F31DC25EED008F296C /* Array+utilities.swift in Sources */,
+				78389E491ECC26B0008898E7 /* Class+utilities.swift in Sources */,
 				5E3F86E11DC25EDF008F296C /* LogInformation.swift in Sources */,
 				5E3F86F81DC25F0F008F296C /* LoggerClient.m in Sources */,
 				5E3F86ED1DC25EE3008F296C /* NSLogAppender.swift in Sources */,
@@ -768,6 +775,7 @@
 				5E3E72051B7A186700EEE46B /* StdOutAppender.swift in Sources */,
 				5E3E72061B7A186700EEE46B /* FileAppender.swift in Sources */,
 				5E3E72071B7A186700EEE46B /* NSLoggerAppender.swift in Sources */,
+				78389E481ECC26B0008898E7 /* Class+utilities.swift in Sources */,
 				5E3E72081B7A186700EEE46B /* NSLogAppender.swift in Sources */,
 				5E3E72091B7A186700EEE46B /* ASLAppender.swift in Sources */,
 				5E3E720A1B7A186700EEE46B /* Formatter.swift in Sources */,

--- a/Log4swift/Appenders/Appender.swift
+++ b/Log4swift/Appenders/Appender.swift
@@ -74,3 +74,23 @@ This class is the base class, from which all appenders should inherit.
     }
   }
 }
+
+fileprivate struct AppenderSubclassEnumerator {
+  static let availableAppenderTypes: [Appender.Type] = getAvailableAppenderTypes
+  
+  static private var getAvailableAppenderTypes: [Appender.Type] {
+    let motherClassInfo = ClassInfo(Appender.self)
+    
+    let result = motherClassInfo.subclasses.map {
+      return $0.classObject as! Appender.Type
+    }
+    
+    return result
+  }
+}
+
+extension Appender {
+  static var availableAppenderTypes: [Appender.Type] {
+    return AppenderSubclassEnumerator.availableAppenderTypes
+  }
+}

--- a/Log4swift/Appenders/FileAppender.swift
+++ b/Log4swift/Appenders/FileAppender.swift
@@ -29,7 +29,7 @@ public class FileAppender : Appender {
     case FilePath = "FilePath"
   }
   
-  internal var filePath : String {
+  public private(set) var filePath : String {
     didSet {
       if let safeHandler = self.fileHandler {
         safeHandler.closeFile()

--- a/Log4swift/Appenders/FileAppender.swift
+++ b/Log4swift/Appenders/FileAppender.swift
@@ -29,7 +29,7 @@ public class FileAppender : Appender {
     case FilePath = "FilePath"
   }
   
-  public private(set) var filePath : String {
+  public internal(set) var filePath : String {
     didSet {
       if let safeHandler = self.fileHandler {
         safeHandler.closeFile()

--- a/Log4swift/Appenders/NSLoggerAppender.swift
+++ b/Log4swift/Appenders/NSLoggerAppender.swift
@@ -23,6 +23,7 @@ import Foundation
 /**
 The NSLogger appender relies on the NSLogger project (see https://github.com/fpillet/NSLogger) to send log messages over the network.  
 */
+@available(iOS 8.0, *)
 public class NSLoggerAppender : Appender {
   public enum DictionaryKey: String {
     case BonjourServiceName = "BonjourServiceName"

--- a/Log4swift/Logger.swift
+++ b/Log4swift/Logger.swift
@@ -115,7 +115,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   
   /// Create a logger that is a child of the given logger.
   /// The created logger will follow the parent logger's configuration until it is manually modified.
-  convenience init(parentLogger: Logger, identifier: String) {
+  public convenience init(parentLogger: Logger, identifier: String) {
     self.init(identifier: identifier, level: parentLogger.thresholdLevel, appenders: [Appender]() + parentLogger.appenders)
     self.parent = parentLogger
   }

--- a/Log4swift/LoggerFactory+loadFromFile.swift
+++ b/Log4swift/LoggerFactory+loadFromFile.swift
@@ -148,10 +148,11 @@ extension LoggerFactory : FileObserverDelegate {
   }
   
   private func appenderForClassName(_ className: String) -> Appender.Type? {
-    #if !os(watchOS)
-        if className.lowercased() == "nsloggerappender" {
-            return NSLoggerAppender.self
-        }
+    let nsLoggerAppenderType: Appender.Type?
+    #if os(watchOS)
+      nsLoggerAppenderType = nil
+    #else
+      nsLoggerAppenderType = NSLoggerAppender.self
     #endif
     
     let type: Appender.Type?
@@ -162,6 +163,8 @@ extension LoggerFactory : FileObserverDelegate {
       type = FileAppender.self
     case "nslogappender":
       type = NSLogAppender.self
+    case "nsloggerappender":
+      type = nsLoggerAppenderType
     case "aslappender":
       type = ASLAppender.self
     default:

--- a/Log4swift/LoggerFactory+loadFromFile.swift
+++ b/Log4swift/LoggerFactory+loadFromFile.swift
@@ -148,14 +148,18 @@ extension LoggerFactory : FileObserverDelegate {
   }
   
   private func appenderForClassName(_ className: String) -> Appender.Type? {
+    #if !os(watchOS)
+        if className.lowercased() == "nsloggerappender" {
+            return NSLoggerAppender.self
+        }
+    #endif
+    
     let type: Appender.Type?
     switch(className.lowercased()) {
     case "stdoutappender":
       type = StdOutAppender.self
     case "fileappender":
       type = FileAppender.self
-    case "nsloggerappender":
-      type = NSLoggerAppender.self
     case "nslogappender":
       type = NSLogAppender.self
     case "aslappender":

--- a/Log4swift/LoggerFactory+loadFromFile.swift
+++ b/Log4swift/LoggerFactory+loadFromFile.swift
@@ -148,29 +148,15 @@ extension LoggerFactory : FileObserverDelegate {
   }
   
   private func appenderForClassName(_ className: String) -> Appender.Type? {
-    let nsLoggerAppenderType: Appender.Type?
-    #if os(watchOS)
-      nsLoggerAppenderType = nil
-    #else
-      nsLoggerAppenderType = NSLoggerAppender.self
-    #endif
+    let classNameLowercased = className.lowercased()
     
-    let type: Appender.Type?
-    switch(className.lowercased()) {
-    case "stdoutappender":
-      type = StdOutAppender.self
-    case "fileappender":
-      type = FileAppender.self
-    case "nslogappender":
-      type = NSLogAppender.self
-    case "nsloggerappender":
-      type = nsLoggerAppenderType
-    case "aslappender":
-      type = ASLAppender.self
-    default:
-      type = nil
+    for appenderType in Appender.availableAppenderTypes {
+      if NSStringFromClass(appenderType).lowercased().hasSuffix("." + classNameLowercased)  {
+        return appenderType
+      }
     }
-    return type
+    
+    return nil
   }
 
   private func processLoggerDictionary(_ dictionary: Dictionary<String, Any>, appenders: Array<Appender>) throws -> Logger {

--- a/Log4swift/LoggerFactory.swift
+++ b/Log4swift/LoggerFactory.swift
@@ -155,6 +155,7 @@ extension LoggerFactory {
   
   **This method will replace your current configuration by a new one.**
   */
+  #if !os(watchOS)
   public func configureForNSLogger(remoteHost: String = "127.0.0.1", remotePort: UInt32 = 50000, thresholdLevel: LogLevel = .Debug) {
     self.resetConfiguration()
     
@@ -163,4 +164,5 @@ extension LoggerFactory {
     
     self.rootLogger.appenders = [nsloggerAppender]
   }
+  #endif
 }

--- a/Log4swift/Utilities/Class+utilities.swift
+++ b/Log4swift/Utilities/Class+utilities.swift
@@ -1,0 +1,60 @@
+//
+//  ClassInfo.swift
+//  Log4swift
+//
+//  Created by Igor Makarov on 17/05/2017.
+//  Copyright © 2017 jerome. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+internal struct ClassInfo {
+  let classObject: AnyClass
+  
+  init(_ classObject: AnyClass) {
+    self.classObject = classObject
+  }
+  
+  var superclassInfo: ClassInfo? {
+    if let superclassObject: AnyClass = class_getSuperclass(self.classObject) {
+      return ClassInfo(superclassObject)
+    }
+    return nil
+  }
+
+  public func isSubclass(of cls: ClassInfo) -> Bool {
+    if let superclass = self.superclassInfo {
+      return superclass.classObject == cls.classObject || superclass.isSubclass(of: cls)
+    }
+    return false
+  }
+  
+  public var subclasses: [ClassInfo] {
+    var subclassList = [ClassInfo]()
+    
+    var count = UInt32(0)
+    let classList = objc_copyClassList(&count)!
+    
+    for i in 0..<Int(count) {
+      let classInfo = ClassInfo(classList[i]!)
+      if classInfo.isSubclass(of: self) {
+        subclassList.append(classInfo)
+      }
+    }
+    
+    return subclassList
+  }
+}
+

--- a/Log4swift/log4swift.h
+++ b/Log4swift/log4swift.h
@@ -27,8 +27,9 @@ FOUNDATION_EXPORT double log4swiftVersionNumber;
 FOUNDATION_EXPORT const unsigned char log4swiftVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <log4swift/PublicHeader.h>
+#if !TARGET_OS_WATCH
 #import "NSLogger.h"
 #import "LoggerClient.h"
 #import "LoggerCommon.h"
-
+#endif
 #import "ASLWrapper.h"


### PR DESCRIPTION
This adds watchOS target support in the podspec.

I couldn't figure out whether NSLogger can be supported on watchOS so I just disabled it and its corresponding appender when the target is watchOS. Consider moving it into a separate subspec?