### PR TITLE
Fixed Swift4 warning for deprecated `String.characters`.

### DIFF
--- a/Log4swift/Formatters/PatternFormatter.swift
+++ b/Log4swift/Formatters/PatternFormatter.swift
@@ -119,7 +119,7 @@ Available markers are :
     fileprivate func parsePattern(_ pattern: String) throws -> [FormattingClosure] {
       parsedClosuresSequence = [FormattingClosure]()
       
-      for currentCharacter in pattern.characters
+      for currentCharacter in pattern
       {
         switch(parserStatus.machineState) {
         case .Text where currentCharacter == "%":
@@ -192,7 +192,7 @@ Available markers are :
       if let closureForMarker = self.closureForMarker(markerName, parameters: parameters) {
         parsedClosuresSequence.append({(message, info) in closureForMarker(parameters, message, info) })
       } else {
-        parserStatus.charactersAccumulator += "%\(markerName)".characters
+        parserStatus.charactersAccumulator += "%\(markerName)"
       }
     }
     

--- a/Log4swift/LoggerFactory+loadFromFile.swift
+++ b/Log4swift/LoggerFactory+loadFromFile.swift
@@ -86,7 +86,7 @@ extension LoggerFactory : FileObserverDelegate {
         do {
           let identifierA: String = try self.identifierFromConfigurationDictionary(a)
           let identifierB: String = try self.identifierFromConfigurationDictionary(b)
-          return identifierA.characters.count < identifierB.characters.count
+          return identifierA.count < identifierB.count
         } catch {
           return false
         }

--- a/Log4swift/Utilities/String+utilities.swift
+++ b/Log4swift/Utilities/String+utilities.swift
@@ -58,7 +58,7 @@ extension String {
       return self
     }
     
-    if self.characters.count > abs(width) {
+    if self.count > abs(width) {
       if width < 0 {
 				paddedString = String(self.suffix(abs(width)))
       } else {
@@ -66,9 +66,9 @@ extension String {
       }
     }
 
-    if self.characters.count < abs(width) {
+    if self.count < abs(width) {
       if width < 0 {
-				paddedString = " ".padding(toLength: abs(width) - self.characters.count, withPad: " ", startingAt: 0) + self
+				paddedString = " ".padding(toLength: abs(width) - self.count, withPad: " ", startingAt: 0) + self
       } else {
         paddedString = self.padding(toLength: width, withPad: " ", startingAt: 0)
       }

--- a/Log4swiftTests/Appenders/FileAppenderTests.swift
+++ b/Log4swiftTests/Appenders/FileAppenderTests.swift
@@ -117,7 +117,7 @@ class FileAppenderTests: XCTestCase {
       
       // Validate
       let fileContent = try NSString(contentsOfFile: tempFilePath, encoding: String.Encoding.utf8.rawValue)
-      XCTAssert(fileContent.length >= logContent.characters.count * 2, "Content of log file should not be just the first ping")
+      XCTAssert(fileContent.length >= logContent.count * 2, "Content of log file should not be just the first ping")
     } catch let error {
       XCTAssert(false, "Error in test : \(error)")
     }

--- a/Log4swiftTests/Formatters/PatternFormatterTests.swift
+++ b/Log4swiftTests/Formatters/PatternFormatterTests.swift
@@ -158,7 +158,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^1973-11-29 [0-2][0-9]:33:09$", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^1973-11-(29|30) [0-2][0-9]:(03|33|18):09$", options: NSRegularExpression.Options())
 		let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -171,7 +171,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^11/29/73 [0-2][0-9]:33:09$", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^11/(29|30)/73 [0-2][0-9]:(03|33|18):09$", options: NSRegularExpression.Options())
     let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -184,7 +184,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^11/29/73 [0-2][0-9]:33:09  $", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^11/(29|30)/73 [0-2][0-9]:(03|33|18):09  $", options: NSRegularExpression.Options())
     let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -197,7 +197,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^     11/29/73 [0-2][0-9]:33$", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^     11/(29|30)/73 [0-2][0-9]:(03|33|18)$", options: NSRegularExpression.Options())
     let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -210,7 +210,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^11/29/73 [0-2][0-9]:33$", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^11/(29|30)/73 [0-2][0-9]:(03|33|18)$", options: NSRegularExpression.Options())
 		let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -498,7 +498,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^1973-11-29 [0-2][0-9]:33:09.876$", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^1973-11-(29|30) [0-2][0-9]:(03|33|18):09.876$", options: NSRegularExpression.Options())
     let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -511,7 +511,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^29.11.73 [0-2][0-9]:33:09.876$", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^(29|30).11.73 [0-2][0-9]:(03|33|18):09.876$", options: NSRegularExpression.Options())
     let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -524,7 +524,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^29.11.73 [0-2][0-9]:33:09.876  $", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^(29|30).11.73 [0-2][0-9]:(03|33|18):09.876  $", options: NSRegularExpression.Options())
     let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }
@@ -537,7 +537,7 @@ class PatternFormatterTests: XCTestCase {
     let formattedMessage = formatter.format(message: "", info: info)
     
     // Validate (regex used to avoid problems with time shift)
-    let validationRegexp = try! NSRegularExpression(pattern: "^  29.11.73 [0-2][0-9]:33:09.876$", options: NSRegularExpression.Options())
+    let validationRegexp = try! NSRegularExpression(pattern: "^  (29|30).11.73 [0-2][0-9]:(03|33|18):09.876$", options: NSRegularExpression.Options())
     let matches = validationRegexp.matches(in: formattedMessage, options: NSRegularExpression.MatchingOptions(), range: NSMakeRange(0, formattedMessage.lengthOfBytes(using: String.Encoding.utf8)))
     XCTAssert(matches.count > 0, "Formatted date '\(formattedMessage)' is not valid")
   }

--- a/Log4swiftTests/LoggerTests.swift
+++ b/Log4swiftTests/LoggerTests.swift
@@ -677,7 +677,7 @@ class LoggerTests: XCTestCase {
     
     let thread = Thread(target: myInstance, selector: #selector(myInstance.loggingMethod(_:)), object: expectation)
     thread.name = "someThreadName"
-    thread.stackSize = 16000
+    thread.stackSize = 4 * 4096
     thread.threadPriority = 0.75
     thread.start()
     


### PR DESCRIPTION
- Fix `PatternFormatterTests` unit tests to work at any timezones (like GMT+3).
- Fixed `NSInvalidArgumentException` exception in `testLoggerLogsNSThreadNameAndId` test.
