### PR TITLE
Add @objc annotations to various methods and properties

### DIFF
--- a/Log4swift/Appenders/ASLAppender.swift
+++ b/Log4swift/Appenders/ASLAppender.swift
@@ -26,6 +26,7 @@ This appender will send messages to ASL, the Apple System Log.
 public class ASLAppender : Appender {
   internal let aslClient = ASLWrapper ()
   
+  @objc
   required public init(_ identifier: String) {
     super.init(identifier)
   }

--- a/Log4swift/Appenders/Appender.swift
+++ b/Log4swift/Appenders/Appender.swift
@@ -31,7 +31,7 @@ This class is the base class, from which all appenders should inherit.
   }
   
   @objc let identifier: String
-  public var thresholdLevel = LogLevel.Debug
+  @objc public var thresholdLevel = LogLevel.Debug
   public var formatter: Formatter?
   
   @objc

--- a/Log4swift/Appenders/Appender.swift
+++ b/Log4swift/Appenders/Appender.swift
@@ -30,10 +30,11 @@ This class is the base class, from which all appenders should inherit.
     case FormatterId = "FormatterId"
   }
   
-  let identifier: String
+  @objc let identifier: String
   public var thresholdLevel = LogLevel.Debug
   public var formatter: Formatter?
   
+  @objc
   public required init(_ identifier: String) {
     self.identifier = identifier
   }

--- a/Log4swift/Appenders/AppleUnifiedLoggerAppender.swift
+++ b/Log4swift/Appenders/AppleUnifiedLoggerAppender.swift
@@ -18,10 +18,12 @@
 // limitations under the License.
 //
 
+import Foundation
 import os.log
 
 @available(iOS 10.0, macOS 10.12, watchOS 3, *)
-class AppleUnifiedLoggerAppender : Appender {
+@objc
+public class AppleUnifiedLoggerAppender : Appender {
   private static var levelsMapping = [
     LogLevel.Trace: OSLogType.debug,
     LogLevel.Debug: OSLogType.debug,

--- a/Log4swift/Appenders/FileAppender.swift
+++ b/Log4swift/Appenders/FileAppender.swift
@@ -29,6 +29,7 @@ public class FileAppender : Appender {
     case FilePath = "FilePath"
   }
   
+  @objc
   public internal(set) var filePath : String {
     didSet {
       if let safeHandler = self.fileHandler {
@@ -42,6 +43,7 @@ public class FileAppender : Appender {
   private var fileHandler: FileHandle?
   private var didLogFailure = false
 
+  @objc
   public init(identifier: String, filePath: String) {
     self.fileHandler = nil
     self.filePath = (filePath as NSString).expandingTildeInPath

--- a/Log4swift/Appenders/StdOutAppender.swift
+++ b/Log4swift/Appenders/StdOutAppender.swift
@@ -56,6 +56,7 @@ public class StdOutAppender: Appender {
   internal fileprivate(set) var textColors = [LogLevel: TTYColor]()
   internal fileprivate(set) var backgroundColors = [LogLevel: TTYColor]()
   
+  @objc
   public required init(_ identifier: String) {
     let xcodeColors = ProcessInfo().environment["XcodeColors"]
     let terminalType = ProcessInfo().environment["TERM"]

--- a/Log4swift/Appenders/SystemAppender.swift
+++ b/Log4swift/Appenders/SystemAppender.swift
@@ -45,6 +45,7 @@ class SystemAppender: Appender {
   
   internal let backendAppender: Appender?
   
+  @objc
   required init(_ identifier: String) {
     if #available(iOS 10.0, macOS 10.12, watchOS 3, *) {
       self.backendAppender = AppleUnifiedLoggerAppender(identifier)

--- a/Log4swift/Appenders/SystemAppender.swift
+++ b/Log4swift/Appenders/SystemAppender.swift
@@ -18,6 +18,8 @@
 // limitations under the License.
 //
 
+import Foundation
+
 /**
  The SystemAppender is a meta-appender, that will select the preferable appender depending on the system.
  - For MacOS 10.11, it will be an ASL appender.

--- a/Log4swift/Appenders/SystemAppender.swift
+++ b/Log4swift/Appenders/SystemAppender.swift
@@ -27,8 +27,9 @@ import Foundation
  - ...
  This appender is the best suited one for production software that targets multiple platforms.
  */
-class SystemAppender: Appender {
-  override var thresholdLevel: LogLevel {
+@objc
+public class SystemAppender: Appender {
+  public override var thresholdLevel: LogLevel {
     get {
       return self.backendAppender?.thresholdLevel ?? .Off
     }
@@ -36,7 +37,7 @@ class SystemAppender: Appender {
       self.backendAppender?.thresholdLevel = newValue
     }
   }
-  override var formatter: Formatter? {
+  public override var formatter: Formatter? {
     get {
       return self.backendAppender?.formatter
     }
@@ -48,7 +49,7 @@ class SystemAppender: Appender {
   internal let backendAppender: Appender?
   
   @objc
-  required init(_ identifier: String) {
+  public required init(_ identifier: String) {
     if #available(iOS 10.0, macOS 10.12, watchOS 3, *) {
       self.backendAppender = AppleUnifiedLoggerAppender(identifier)
     } else if #available(iOS 9.0, macOS 10.9, *) {
@@ -66,11 +67,11 @@ class SystemAppender: Appender {
     super.init(identifier)
   }
   
-  override func update(withDictionary dictionary: Dictionary<String, Any>, availableFormatters: Array<Formatter>) throws {
+  public override func update(withDictionary dictionary: Dictionary<String, Any>, availableFormatters: Array<Formatter>) throws {
     try self.backendAppender?.update(withDictionary: dictionary, availableFormatters: availableFormatters)
   }
   
-  override func performLog(_ log: String, level: LogLevel, info: LogInfoDictionary) {
+  public override func performLog(_ log: String, level: LogLevel, info: LogInfoDictionary) {
     self.backendAppender?.performLog(log, level: level, info: info)
   }
 }

--- a/Log4swift/Logger.swift
+++ b/Log4swift/Logger.swift
@@ -53,6 +53,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
 
   /// If asynchronous is true, only the minimum of work will be done on the main thread, the rest will be deffered to a low priority background thread.
   /// The order of the messages will be preserved in async mode.
+  @objc
   public var asynchronous: Bool {
     get {
       if let parent = self.parent {
@@ -71,6 +72,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   /// For example, if the threshold is Warning:
   /// * logs issued with a Debug or Info will be ignored
   /// * logs issued wiht a Warning, Error or Fatal level will be processed
+  @objc
   public var thresholdLevel: LogLevel {
     get {
       if let parent = self.parent {
@@ -86,6 +88,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   }
 
   /// The list of destination appenders for the log messages.
+  @objc
   public var appenders: [Appender] {
     get {
       if let parent = self.parent {
@@ -103,18 +106,21 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   
   /// Creates a new logger with the given identifier, log level and appenders.
   /// The identifier will not be modifiable, and should not be an empty string.
+  @objc
   public init(identifier: String, level: LogLevel = LogLevel.Debug, appenders: [Appender] = []) {
     self.identifier = identifier
     self.thresholdLevelStorage = level
     self.appendersStorage = appenders
   }
 
+  @objc
   convenience override init() {
     self.init(identifier: "", appenders: Logger.createDefaultAppenders())
   }
   
   /// Create a logger that is a child of the given logger.
   /// The created logger will follow the parent logger's configuration until it is manually modified.
+  @objc
   public convenience init(parentLogger: Logger, identifier: String) {
     self.init(identifier: identifier, level: parentLogger.thresholdLevel, appenders: [Appender]() + parentLogger.appenders)
     self.parent = parentLogger


### PR DESCRIPTION
As of Swift 4.0, @objc annotation inference has gotten very conservative. 

Symbols that used to be exported to ObjC no longer are by default.

This PR adds annotations for various methods so that they can be called from ObjC.