### PR TITLE
restore watchOS support

### DIFF
--- a/Log4swift.podspec
+++ b/Log4swift.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
   s.author       = { "Jerome Duquennoy" => "jerome@duquennoy.fr" }
 
   s.ios.deployment_target = "8.0"
+  s.watchos.deployment_target = "2.0"
   s.osx.deployment_target = "10.10"
 
   s.source       = { :git => "https://github.com/jduquennoy/Log4swift.git", :tag => "v1.0.4" }


### PR DESCRIPTION
I've noticed that watchOS support has been removed due to pod linter erroring.  

However, users of this pod (including myself) have been relying on this support in production code.

The correct solution in my opinion is to solve the linter problem or silence the errors. I can guarantee you that the code works well on the Apple Watch as I've been using it for debugging myself.

By the way, I tried linting the pod on CocoaPods 1.5.3 and it seems that OSX also errors out. These are linter problems and shouldn't be blocking for the platform support.

Sorry if my tone is harsh, I'm just slightly distraught over this breaking change.