### PR TITLE
os_log refinement

### DIFF
--- a/Log4swift/Appenders/AppleUnifiedLoggerAppender.swift
+++ b/Log4swift/Appenders/AppleUnifiedLoggerAppender.swift
@@ -38,7 +38,7 @@ public class AppleUnifiedLoggerAppender : Appender {
     guard let logType = type(of: self).levelsMapping[level] else { return }
     let loggerName = info[LogInfoKeys.LoggerName] as? String ?? "-"
     let osLog = self.osLog(ForLoggerName: loggerName)
-    os_log("%@", log: osLog, type: logType, log)
+    os_log("%{public}@", log: osLog, type: logType, log)
   }
   
   private func osLog(ForLoggerName loggerName: String) -> OSLog {


### PR DESCRIPTION
This PR covers two refinements to the os_log appender:

- Make messages `{public}` so that they appear when debugger is unconnected. Current version renders them all as `<private>` in the Console.
- Turn `.debug` log level into `.info` when compiling agains the simulator because the simulator logs filter debug level out, no matter the setting. It seems to be a well-known problem.