### PR TITLE
Fix crash on XCode 11.4+ (`objc_copyClassList`)

### DIFF
--- a/Log4swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Log4swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Log4swift/Utilities/Array+utilities.swift
+++ b/Log4swift/Utilities/Array+utilities.swift
@@ -22,7 +22,7 @@ import Foundation
 
 extension Array {
   public func find(filter:(Array.Iterator.Element) -> Bool) -> Element? {
-		if let itemIndex = self.index(where: filter) {
+    if let itemIndex = self.firstIndex(where: filter) {
       return self[itemIndex]
     }
     return nil

--- a/Log4swift/Utilities/Class+utilities.swift
+++ b/Log4swift/Utilities/Class+utilities.swift
@@ -45,7 +45,7 @@ internal struct ClassInfo {
     var subclassList = [ClassInfo]()
     
     var count = UInt32(0)
-    let classList = objc_copyClassList(&count)!
+    let classList = UnsafePointer<AnyClass>(objc_copyClassList(&count))!
     
     for i in 0..<Int(count) {
       let classInfo = ClassInfo(classList[i])
@@ -53,6 +53,8 @@ internal struct ClassInfo {
         subclassList.append(classInfo)
       }
     }
+
+    free(UnsafeMutableRawPointer(mutating: classList))
     
     return subclassList
   }

--- a/Log4swift/Utilities/MultithreadingUtilities.swift
+++ b/Log4swift/Utilities/MultithreadingUtilities.swift
@@ -55,7 +55,7 @@ internal final class PThreadMutex {
 
 internal extension PThreadMutex {
   /// Executes a closure as a critical section (not executable concurrently by different threads).
-  internal func sync<R>(execute: () throws -> R) rethrows -> R {
+  func sync<R>(execute: () throws -> R) rethrows -> R {
     self.unbalancedLock()
     defer { self.unbalancedUnlock() }
     return try execute()

--- a/Log4swift/Utilities/String+utilities.swift
+++ b/Log4swift/Utilities/String+utilities.swift
@@ -22,7 +22,7 @@ extension StringProtocol {
   /// Return a new string by removing everything after the last occurence of the provided marker and including the marker.  
   /// If the marker is not found, an empty string is returned.
   public func stringByRemovingLastComponent(withDelimiter delimiter: String) -> SubSequence? {
-    guard let markerIndex = self.reversed().index(of: Character(delimiter)) else { return nil }
+    guard let markerIndex = self.reversed().firstIndex(of: Character(delimiter)) else { return nil }
     let endIndex = self.index(markerIndex.base, offsetBy: -1)
 
     let result = self[self.startIndex..<endIndex]

--- a/Log4swiftTests/Appenders/StdOutAppenderTests.swift
+++ b/Log4swiftTests/Appenders/StdOutAppenderTests.swift
@@ -114,7 +114,7 @@ class StdOutAppenderTests: XCTestCase {
 
   func testUpdatingAppenderFromDictionaryWithInvalidThresholdThrowsError() {
     let dictionary = [LoggerFactory.DictionaryKey.Identifier.rawValue: "testAppender",
-      StdOutAppender.DictionaryKey.ThresholdLevel.rawValue: "invalid level"]
+      Appender.DictionaryKey.ThresholdLevel.rawValue: "invalid level"]
     let appender = StdOutAppender("test appender")
 
     // Execute & validate
@@ -123,7 +123,7 @@ class StdOutAppenderTests: XCTestCase {
   
   func testUpdatingAppenderFromDictionaryWithThresholdUsesSpecifiedValue() {
     let dictionary = [LoggerFactory.DictionaryKey.Identifier.rawValue: "testAppender",
-      StdOutAppender.DictionaryKey.ThresholdLevel.rawValue: LogLevel.Info.description]
+      Appender.DictionaryKey.ThresholdLevel.rawValue: LogLevel.Info.description]
     let appender = StdOutAppender("test appender")
     appender.thresholdLevel = .Debug
     


### PR DESCRIPTION
Applied solution from https://bugs.swift.org/browse/SR-12344

I tried to compile and run unit tests on xcode 10.3, 11.3.1 and 11.5 - all works ok.