### PR TITLE
Fix "AppleUnifiedLogger" registration unit tests.

### DIFF
--- a/Log4swift.xcodeproj/project.pbxproj
+++ b/Log4swift.xcodeproj/project.pbxproj
@@ -1092,7 +1092,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				PRODUCT_BUNDLE_IDENTIFIER = fr.duquennoy.log4swiftTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.duquennoy.log4swiftPerfTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1105,7 +1105,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				PRODUCT_BUNDLE_IDENTIFIER = fr.duquennoy.log4swiftTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.duquennoy.log4swiftPerfTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Log4swift/Appenders/AppendersRegistry.swift
+++ b/Log4swift/Appenders/AppendersRegistry.swift
@@ -21,8 +21,7 @@ public struct AppendersRegistry {
       ASLAppender.self,
       SystemAppender.self
     ]
-    if #available(macOS 12.0, *),
-      #available(iOSApplicationExtension 10.0, *) {
+    if #available(macOS 10.12, iOSApplicationExtension 10.0, *) {
       appenders.append(AppleUnifiedLoggerAppender.self)
     }
     return appenders

--- a/Log4swiftTests/Appenders/AppleUnifiedLoggerAppenderTests.swift
+++ b/Log4swiftTests/Appenders/AppleUnifiedLoggerAppenderTests.swift
@@ -32,7 +32,7 @@ class AppleUnifiedLoggerAppenderTests: XCTestCase {
   func testLoggingTwiceWithTheSameLoggerNameLogsMessagesCorrectly() throws {
     let infoDictionary = [LogInfoKeys.LoggerName: testLoggerName]
     let appender = AppleUnifiedLoggerAppender("testAppender")
-    let logMessage = "Test info message" // " + UUID().uuidString
+    let logMessage = "Test info message " + UUID().uuidString
     
     // Execute
     appender.log(logMessage, level: LogLevel.Info, info: infoDictionary)

--- a/Log4swiftTests/Info.plist
+++ b/Log4swiftTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>fr.duquennoy.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
- Corrected `if #available` statement.
- Fixed fragile `testLoggingTwiceWithTheSameLoggerNameLogsMessagesCorrectly`
Also:
- Fixed warning about "PRODUCT_BUNDLE_IDENTIFIER" and info plist.