### PR TITLE
Fix registration of "AppleUnifiedLogger" in case iOS

### DIFF
--- a/Log4swift/Appenders/AppendersRegistry.swift
+++ b/Log4swift/Appenders/AppendersRegistry.swift
@@ -21,7 +21,7 @@ public struct AppendersRegistry {
       ASLAppender.self,
       SystemAppender.self
     ]
-    if #available(macOS 10.12, iOSApplicationExtension 10.0, *) {
+    if #available(iOS 10.0, macOS 10.12, watchOS 3, *) {
       appenders.append(AppleUnifiedLoggerAppender.self)
     }
     return appenders


### PR DESCRIPTION
`if #available` should be exactly the same as it specified for the class itself.