### PR TITLE
Added new `timeProvider` property to a logger.

### DIFF
--- a/Log4swift/Logger.swift
+++ b/Log4swift/Logger.swift
@@ -44,13 +44,13 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   
   /// The UTI string that identifies the logger. Example : product.module.feature
   public let identifier: String
-  
+
   internal var parent: Logger?
   
   private var thresholdLevelStorage: LogLevel
   private var appendersStorage: [Appender]
   private var asynchronousStorage = false
-  private var timeProviderStorage: (() -> Date)?
+  private var timeProviderStorage: () -> Date = Date.init
 
   /// If asynchronous is true, only the minimum of work will be done on the main thread, the rest will be deffered to a low priority background thread.
   /// The order of the messages will be preserved in async mode.
@@ -105,7 +105,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   }
 
   /// Gets/sets external time provider for log messages.
-  /// If `nil` then default behavior `Date()` will be used.
+  /// Default behavior is just `Date()`.
   ///
   /// Allows to "mock" the time - could be useful in unit tests
   /// which may run on some "virtual" time instead of real one.
@@ -114,7 +114,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
   /// (on the `rootLogger` for example) - entire sub-hierarchy of loggers will have it.
   ///
   @objc
-  public var timeProvider: (() -> Date)? {
+  public var timeProvider: () -> Date {
     get {
       if let parent = self.parent {
         return parent.timeProvider
@@ -260,7 +260,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
       var info: LogInfoDictionary = [
         .LoggerName: self.identifier,
         .LogLevel: level,
-        .Timestamp: (self.timeProvider?() ?? Date()).timeIntervalSince1970,
+        .Timestamp: self.timeProvider().timeIntervalSince1970,
         .ThreadId: currentThreadId(),
         .ThreadName: currentThreadName()
       ]
@@ -289,7 +289,7 @@ A logger is identified by a UTI identifier, it defines a threshold level and a d
       var info: LogInfoDictionary = [
         .LoggerName: self.identifier,
         .LogLevel: level,
-        .Timestamp: (self.timeProvider?() ?? Date()).timeIntervalSince1970,
+        .Timestamp: self.timeProvider().timeIntervalSince1970,
         .ThreadId: currentThreadId(),
         .ThreadName: currentThreadName()
       ]

--- a/Log4swiftTests/LoggerTests.swift
+++ b/Log4swiftTests/LoggerTests.swift
@@ -548,7 +548,7 @@ class LoggerTests: XCTestCase {
     parentLogger.timeProvider = { return testDate }
 
     // Validate
-    XCTAssertEqual(sonLogger.timeProvider?(), testDate)
+    XCTAssertEqual(sonLogger.timeProvider(), testDate)
   }
 
   func testChangingSonLoggerParameterBreakLinkWithParent() {
@@ -605,8 +605,8 @@ class LoggerTests: XCTestCase {
 
     // Validate
     XCTAssertNil(sonLogger.parent)
-    XCTAssertEqual(parentLogger.timeProvider?(), testDate.0)
-    XCTAssertEqual(sonLogger.timeProvider?(), testDate.1)
+    XCTAssertEqual(parentLogger.timeProvider(), testDate.0)
+    XCTAssertEqual(sonLogger.timeProvider(), testDate.1)
   }
   
   func testLoggedTimeIsTakenWhenLogIsRequested() {

--- a/Log4swiftTests/LoggerTests.swift
+++ b/Log4swiftTests/LoggerTests.swift
@@ -539,6 +539,18 @@ class LoggerTests: XCTestCase {
     XCTAssertTrue(sonIsAsynchronous)
   }
   
+  func testLoggerWithParentUsesParentTimeProvider() {
+    let parentLogger = Logger(identifier: "parent.logger", level: .Info, appenders: [MemoryAppender()])
+    let sonLogger = Logger(parentLogger: parentLogger, identifier: "son.logger")
+
+    // Execute
+    let testDate = Date(timeIntervalSince1970: 42)
+    parentLogger.timeProvider = { return testDate }
+
+    // Validate
+    XCTAssertEqual(sonLogger.timeProvider?(), testDate)
+  }
+
   func testChangingSonLoggerParameterBreakLinkWithParent() {
     let parentLogger = Logger(identifier: "parent.logger", level: .Info, appenders: [MemoryAppender()])
     let sonLogger = Logger(parentLogger: parentLogger, identifier: "son.logger")
@@ -565,7 +577,6 @@ class LoggerTests: XCTestCase {
     XCTAssertNil(sonLogger.parent)
   }
 
-  
   func testSettingSonLoggerAsyncStatusBreakLinkWithParent() {
     let parentLogger = Logger(identifier: "parent.logger", level: .Info, appenders: [MemoryAppender()])
     let sonLogger = Logger(parentLogger: parentLogger, identifier: "son.logger")
@@ -578,6 +589,24 @@ class LoggerTests: XCTestCase {
     XCTAssertNil(sonLogger.parent)
     XCTAssertFalse(parentLogger.asynchronous)
     XCTAssertTrue(sonLogger.asynchronous)
+  }
+
+  func testSettingSonLoggerTimeProviderBreakLinkWithParent() {
+    let parentLogger = Logger(identifier: "parent.logger", level: .Info, appenders: [MemoryAppender()])
+    let sonLogger = Logger(parentLogger: parentLogger, identifier: "son.logger")
+    let testDate = (
+      Date(timeIntervalSince1970: 42),
+      Date(timeIntervalSince1970: 13)
+    )
+    parentLogger.timeProvider = { return testDate.0 }
+
+    // Execute
+    sonLogger.timeProvider = { return testDate.1 }
+
+    // Validate
+    XCTAssertNil(sonLogger.parent)
+    XCTAssertEqual(parentLogger.timeProvider?(), testDate.0)
+    XCTAssertEqual(sonLogger.timeProvider?(), testDate.1)
   }
   
   func testLoggedTimeIsTakenWhenLogIsRequested() {
@@ -599,7 +628,22 @@ class LoggerTests: XCTestCase {
     }
   }
 
-  
+  func testLoggedProvidedTime() {
+    let formatter = try! PatternFormatter(identifier:"testFormatter", pattern: "%D{'format':'ss.SSS'}")
+    let appender = MemoryAppender()
+    appender.thresholdLevel = .Debug
+    appender.formatter = formatter
+    let logger = Logger(identifier: "test.identifier", level: .Debug, appenders: [appender])
+
+    logger.timeProvider = { Date(timeIntervalSince1970: 42.147) }
+
+    // Execute
+    logger.debug("This is a debug message")
+
+    // Validate
+    XCTAssertEqual(appender.logMessages[0].message, "42.147")
+  }
+
   func testLoggingStringWithPercentAndNoParametersDoesNotCrash() {
     let appender = MemoryAppender()
     appender.thresholdLevel = .Debug


### PR DESCRIPTION
Allows to set an external time provider closure for log messages.
Default behavior is just `Date()`.

This feature allows to "mock" the time - could be useful in unit tests
which may run on some "virtual" time instead of real one.

Child loggers inherit this value so it's possible to set it only once
(on the `rootLogger` for example) - entire sub-hierarchy of loggers will have it.